### PR TITLE
Add AcademicSection entity and calendar system with templates

### DIFF
--- a/didacta-api/src/main/java/com/didacta/api/application/dto/AcademicSectionDto.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/AcademicSectionDto.java
@@ -1,0 +1,39 @@
+package com.didacta.api.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+public class AcademicSectionDto {
+
+    @Data
+    public static class CreateSection {
+        @NotBlank
+        @Pattern(regexp = "MATERNAL|INICIAL|PREESCOLAR|PRIMARIA|SECUNDARIA|MEDIA_SUPERIOR|EMPRESARIAL",
+                message = "must be a valid education level")
+        private String level;
+
+        @NotBlank
+        @Pattern(regexp = "NONE|SEP_RVOE|UNAM_DGIRE|IPN|OTHER",
+                message = "must be a valid accreditation type")
+        private String accreditationType;
+
+        private String accreditationKey;
+        private String name;
+    }
+
+    @Data
+    @Builder
+    public static class Response {
+        private UUID id;
+        private String level;
+        private String accreditationType;
+        private String accreditationKey;
+        private String name;
+        private Integer displayOrder;
+        private Boolean active;
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/dto/CalendarDto.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/CalendarDto.java
@@ -1,0 +1,123 @@
+package com.didacta.api.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public class CalendarDto {
+
+    // --- Commands ---
+
+    @Data
+    public static class CreateFromTemplate {
+        @NotNull
+        private UUID templateId;
+        private UUID sectionId;
+    }
+
+    @Data
+    public static class CreateEvent {
+        @NotBlank
+        private String name;
+        @NotBlank
+        private String eventType;
+        @NotNull
+        private LocalDate startDate;
+        @NotNull
+        private LocalDate endDate;
+        private Boolean affectsClasses;
+        private Boolean affectsStaff;
+        private String notes;
+    }
+
+    @Data
+    public static class UpdateEvent {
+        private String name;
+        private String eventType;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Boolean affectsClasses;
+        private Boolean affectsStaff;
+        private String notes;
+    }
+
+    // --- Responses ---
+
+    @Data
+    @Builder
+    public static class TemplateResponse {
+        private UUID id;
+        private String code;
+        private String name;
+        private String description;
+        private String yearLabel;
+        private String periodType;
+        private String authority;
+        private String applicableLevels;
+        private Boolean requiresAccreditation;
+        private String accreditationAuthority;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Integer expectedClassDays;
+    }
+
+    @Data
+    @Builder
+    public static class TemplateDetailResponse {
+        private TemplateResponse template;
+        private List<TemplateEventResponse> events;
+    }
+
+    @Data
+    @Builder
+    public static class TemplateEventResponse {
+        private UUID id;
+        private String name;
+        private String eventType;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Boolean affectsClasses;
+        private Boolean affectsStaff;
+        private Boolean isMandatory;
+        private Integer sortOrder;
+    }
+
+    @Data
+    @Builder
+    public static class CalendarResponse {
+        private UUID id;
+        private UUID sectionId;
+        private String sectionLevel;
+        private UUID schoolYearId;
+        private UUID sourceTemplateId;
+        private String name;
+        private String status;
+    }
+
+    @Data
+    @Builder
+    public static class CalendarDetailResponse {
+        private CalendarResponse calendar;
+        private List<EventResponse> events;
+    }
+
+    @Data
+    @Builder
+    public static class EventResponse {
+        private UUID id;
+        private String name;
+        private String eventType;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Boolean affectsClasses;
+        private Boolean affectsStaff;
+        private Boolean isFromTemplate;
+        private Boolean isDeleted;
+        private String notes;
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/dto/OnboardingCommand.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/OnboardingCommand.java
@@ -25,6 +25,17 @@ public class OnboardingCommand {
         private String role;
         private boolean hasMultipleCampuses;
         private String campusName;
+        private List<SectionEntry> sections;
+    }
+
+    @Data
+    public static class SectionEntry {
+        @NotBlank
+        private String level;
+        @NotBlank
+        @Pattern(regexp = "NONE|SEP_RVOE|UNAM_DGIRE|IPN|OTHER", message = "must be a valid accreditation type")
+        private String accreditationType;
+        private String accreditationKey;
     }
 
     @Data
@@ -34,6 +45,7 @@ public class OnboardingCommand {
         private String gradeLevel;
         private String shift;
         private UUID campusId;
+        private UUID sectionId;
     }
 
     @Data
@@ -85,10 +97,9 @@ public class OnboardingCommand {
         @NotBlank
         @Email
         private String email;
-        @NotBlank
         private String fullName;
         @NotBlank
-        @Pattern(regexp = "OWNER|DIRECTOR|COORDINATOR|TEACHER", message = "must be one of: OWNER, DIRECTOR, COORDINATOR, TEACHER")
+        @Pattern(regexp = "OWNER|DIRECTOR|COORDINATOR|TEACHER|ADMIN", message = "must be one of: OWNER, DIRECTOR, COORDINATOR, TEACHER, ADMIN")
         private String role;
         private UUID groupId;
     }

--- a/didacta-api/src/main/java/com/didacta/api/application/dto/OnboardingResult.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/OnboardingResult.java
@@ -14,6 +14,20 @@ public class OnboardingResult {
         private UserDto user;
         private TenantDto tenant;
         private OnboardingStatus onboarding;
+        private SetupProgress setupProgress;
+    }
+
+    @Data
+    @Builder
+    public static class SetupProgress {
+        private boolean hasGroup;
+        private boolean hasStudents;
+        private boolean hasAttendance;
+        private boolean hasCollaborators;
+        private int groupCount;
+        private int studentCount;
+        private int collaboratorCount;
+        private String suggestedNextAction;
     }
 
     @Data
@@ -111,6 +125,16 @@ public class OnboardingResult {
         private String name;
         private String gradeLevel;
         private String shift;
+        private UUID sectionId;
+    }
+
+    @Data
+    @Builder
+    public static class AcademicSectionDto {
+        private UUID id;
+        private String level;
+        private String accreditationType;
+        private String accreditationKey;
     }
 
     @Data

--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/GetCalendarTemplatesUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/GetCalendarTemplatesUseCase.java
@@ -1,0 +1,11 @@
+package com.didacta.api.application.port.input;
+
+import com.didacta.api.application.dto.CalendarDto;
+
+import java.util.List;
+
+public interface GetCalendarTemplatesUseCase {
+    List<CalendarDto.TemplateResponse> listAll();
+    List<CalendarDto.TemplateResponse> listByLevel(String level);
+    CalendarDto.TemplateDetailResponse getTemplateWithEvents(java.util.UUID templateId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/GetInstitutionInfoUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/GetInstitutionInfoUseCase.java
@@ -10,4 +10,5 @@ public interface GetInstitutionInfoUseCase {
     OnboardingCommand.CreateInstitution getDetails(String keycloakUserId);
     List<OnboardingResult.CampusDto> getCampuses();
     List<OnboardingResult.GroupDto> getGroups();
+    List<OnboardingResult.AcademicSectionDto> getSections();
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageAcademicSectionsUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageAcademicSectionsUseCase.java
@@ -1,0 +1,11 @@
+package com.didacta.api.application.port.input;
+
+import com.didacta.api.application.dto.AcademicSectionDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ManageAcademicSectionsUseCase {
+    List<AcademicSectionDto.Response> listByInstitution();
+    AcademicSectionDto.Response getById(UUID id);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageCalendarUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageCalendarUseCase.java
@@ -1,0 +1,15 @@
+package com.didacta.api.application.port.input;
+
+import com.didacta.api.application.dto.CalendarDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ManageCalendarUseCase {
+    CalendarDto.CalendarResponse createFromTemplate(CalendarDto.CreateFromTemplate command);
+    List<CalendarDto.CalendarResponse> listByInstitution();
+    CalendarDto.CalendarDetailResponse getCalendarWithEvents(UUID calendarId);
+    CalendarDto.EventResponse addEvent(UUID calendarId, CalendarDto.CreateEvent command);
+    CalendarDto.EventResponse updateEvent(UUID calendarId, UUID eventId, CalendarDto.UpdateEvent command);
+    void softDeleteEvent(UUID calendarId, UUID eventId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/AcademicSectionRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/AcademicSectionRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.didacta.api.application.port.output;
+
+import com.didacta.api.domain.model.AcademicSection;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AcademicSectionRepositoryPort {
+    AcademicSection save(AcademicSection section);
+    Optional<AcademicSection> findById(UUID id);
+    List<AcademicSection> findByInstitutionId(UUID institutionId);
+    Optional<AcademicSection> findByInstitutionIdAndLevel(UUID institutionId, String level);
+    void deleteByInstitutionId(UUID institutionId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarEventRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarEventRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.didacta.api.application.port.output;
+
+import com.didacta.api.domain.model.CalendarEvent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CalendarEventRepositoryPort {
+    CalendarEvent save(CalendarEvent event);
+    List<CalendarEvent> saveAll(List<CalendarEvent> events);
+    Optional<CalendarEvent> findById(UUID id);
+    List<CalendarEvent> findByCalendarId(UUID calendarId);
+    void deleteByCalendarId(UUID calendarId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarTemplateRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarTemplateRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.didacta.api.application.port.output;
+
+import com.didacta.api.domain.model.CalendarTemplate;
+import com.didacta.api.domain.model.CalendarTemplateEvent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CalendarTemplateRepositoryPort {
+    List<CalendarTemplate> findAllActive();
+    Optional<CalendarTemplate> findById(UUID id);
+    List<CalendarTemplate> findByApplicableLevelAndAccreditation(String level, boolean requiresAccreditation);
+    List<CalendarTemplateEvent> findEventsByTemplateId(UUID templateId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/InstitutionCalendarRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/InstitutionCalendarRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.didacta.api.application.port.output;
+
+import com.didacta.api.domain.model.InstitutionCalendar;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InstitutionCalendarRepositoryPort {
+    InstitutionCalendar save(InstitutionCalendar calendar);
+    Optional<InstitutionCalendar> findById(UUID id);
+    List<InstitutionCalendar> findByInstitutionId(UUID institutionId);
+    Optional<InstitutionCalendar> findByInstitutionIdAndSectionIdAndSchoolYearId(UUID institutionId, UUID sectionId, UUID schoolYearId);
+    void deleteById(UUID id);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateGroupService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateGroupService.java
@@ -3,11 +3,9 @@ package com.didacta.api.application.usecase;
 import com.didacta.api.application.dto.OnboardingCommand;
 import com.didacta.api.application.dto.OnboardingResult;
 import com.didacta.api.application.port.input.CreateGroupUseCase;
-import com.didacta.api.application.port.output.CampusRepositoryPort;
-import com.didacta.api.application.port.output.GroupRepositoryPort;
-import com.didacta.api.application.port.output.InstitutionRepositoryPort;
-import com.didacta.api.application.port.output.TenantProviderPort;
+import com.didacta.api.application.port.output.*;
 import com.didacta.api.domain.exception.EntityNotFoundException;
+import com.didacta.api.domain.model.AcademicSection;
 import com.didacta.api.domain.model.Campus;
 import com.didacta.api.domain.model.GroupEntity;
 import com.didacta.api.domain.model.Institution;
@@ -15,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,6 +24,7 @@ public class CreateGroupService implements CreateGroupUseCase {
     private final InstitutionRepositoryPort institutionRepository;
     private final GroupRepositoryPort groupRepository;
     private final CampusRepositoryPort campusRepository;
+    private final AcademicSectionRepositoryPort sectionRepository;
     private final TenantProviderPort tenantProvider;
 
     @Override
@@ -61,6 +61,20 @@ public class CreateGroupService implements CreateGroupUseCase {
             Campus defaultCampus = campusRepository.findFirstByInstitutionId(institutionId)
                     .orElseThrow(() -> new EntityNotFoundException("Campus", "default for " + institutionId));
             group.setCampus(defaultCampus);
+        }
+
+        // Set section if provided
+        if (command.getSectionId() != null) {
+            AcademicSection section = sectionRepository.findById(command.getSectionId())
+                    .filter(s -> s.getInstitution().getId().equals(institutionId))
+                    .orElseThrow(() -> new EntityNotFoundException("AcademicSection", command.getSectionId().toString()));
+            group.setSection(section);
+        } else {
+            // Auto-assign first section if only one exists
+            List<AcademicSection> sections = sectionRepository.findByInstitutionId(institutionId);
+            if (sections.size() == 1) {
+                group.setSection(sections.get(0));
+            }
         }
 
         groupRepository.save(group);

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateInstitutionService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateInstitutionService.java
@@ -22,6 +22,10 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
     private final MembershipRepositoryPort membershipRepository;
     private final CampusRepositoryPort campusRepository;
     private final SchoolYearRepositoryPort schoolYearRepository;
+    private final AcademicSectionRepositoryPort sectionRepository;
+    private final CalendarTemplateRepositoryPort templateRepository;
+    private final InstitutionCalendarRepositoryPort calendarRepository;
+    private final CalendarEventRepositoryPort calendarEventRepository;
 
     @Override
     @Transactional
@@ -66,6 +70,10 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
 
         institutionRepository.save(institution);
         membershipRepository.save(membership);
+
+        // Recreate academic sections
+        createOrUpdateSections(institution, command);
+
         return institution;
     }
 
@@ -92,12 +100,113 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
         membershipRepository.save(membership);
 
         // Auto-create school year
-        createCurrentSchoolYear(institution);
+        SchoolYear schoolYear = createCurrentSchoolYear(institution);
+
+        // Create academic sections and auto-assign calendars
+        createOrUpdateSections(institution, command);
 
         return institution;
     }
 
-    private void createCurrentSchoolYear(Institution institution) {
+    private void createOrUpdateSections(Institution institution, OnboardingCommand.CreateInstitution command) {
+        List<OnboardingCommand.SectionEntry> sections = command.getSections();
+
+        if (sections == null || sections.isEmpty()) {
+            // Backward compatibility: create a single section from mainLevel
+            createSectionIfNotExists(institution, command.getMainLevel(), "NONE", null, 0);
+        } else {
+            int order = 0;
+            for (OnboardingCommand.SectionEntry entry : sections) {
+                createSectionIfNotExists(institution, entry.getLevel(),
+                        entry.getAccreditationType(), entry.getAccreditationKey(), order++);
+            }
+        }
+
+        // Auto-assign calendars for each section
+        autoAssignCalendars(institution);
+    }
+
+    private void createSectionIfNotExists(Institution institution, String level,
+                                           String accreditationType, String accreditationKey, int order) {
+        Optional<AcademicSection> existing = sectionRepository.findByInstitutionIdAndLevel(institution.getId(), level);
+        if (existing.isPresent()) {
+            AcademicSection section = existing.get();
+            section.setAccreditationType(accreditationType);
+            section.setAccreditationKey(accreditationKey);
+            section.setDisplayOrder(order);
+            sectionRepository.save(section);
+        } else {
+            AcademicSection section = AcademicSection.builder()
+                    .institution(institution)
+                    .level(level)
+                    .accreditationType(accreditationType != null ? accreditationType : "NONE")
+                    .accreditationKey(accreditationKey)
+                    .displayOrder(order)
+                    .active(true)
+                    .build();
+            sectionRepository.save(section);
+        }
+    }
+
+    private void autoAssignCalendars(Institution institution) {
+        Optional<SchoolYear> schoolYearOpt = schoolYearRepository.findByInstitutionIdAndStatus(institution.getId(), "ACTIVE");
+        if (schoolYearOpt.isEmpty()) return;
+
+        SchoolYear schoolYear = schoolYearOpt.get();
+        List<AcademicSection> sections = sectionRepository.findByInstitutionId(institution.getId());
+
+        for (AcademicSection section : sections) {
+            // Skip if calendar already exists
+            Optional<InstitutionCalendar> existingCal = calendarRepository
+                    .findByInstitutionIdAndSectionIdAndSchoolYearId(institution.getId(), section.getId(), schoolYear.getId());
+            if (existingCal.isPresent()) continue;
+
+            // Find matching template
+            boolean hasAccreditation = !"NONE".equals(section.getAccreditationType());
+            List<CalendarTemplate> templates = templateRepository
+                    .findByApplicableLevelAndAccreditation(section.getLevel(), hasAccreditation);
+
+            if (templates.isEmpty() && hasAccreditation) {
+                // Fall back to non-accreditation templates
+                templates = templateRepository.findByApplicableLevelAndAccreditation(section.getLevel(), false);
+            }
+
+            if (templates.isEmpty()) continue;
+
+            CalendarTemplate template = templates.get(0);
+
+            // Create institution calendar
+            InstitutionCalendar calendar = InstitutionCalendar.builder()
+                    .institution(institution)
+                    .section(section)
+                    .schoolYear(schoolYear)
+                    .sourceTemplate(template)
+                    .name(template.getName())
+                    .status("ACTIVE")
+                    .build();
+            calendarRepository.save(calendar);
+
+            // Copy template events
+            List<CalendarTemplateEvent> templateEvents = templateRepository.findEventsByTemplateId(template.getId());
+            List<CalendarEvent> calendarEvents = templateEvents.stream()
+                    .map(te -> CalendarEvent.builder()
+                            .calendar(calendar)
+                            .sourceTemplateEvent(te)
+                            .name(te.getName())
+                            .eventType(te.getEventType())
+                            .startDate(te.getStartDate())
+                            .endDate(te.getEndDate())
+                            .affectsClasses(te.getAffectsClasses())
+                            .affectsStaff(te.getAffectsStaff())
+                            .isFromTemplate(true)
+                            .isDeleted(false)
+                            .build())
+                    .toList();
+            calendarEventRepository.saveAll(calendarEvents);
+        }
+    }
+
+    private SchoolYear createCurrentSchoolYear(Institution institution) {
         java.time.LocalDate now = java.time.LocalDate.now();
         int startYear = now.getMonthValue() >= 8 ? now.getYear() : now.getYear() - 1;
         int endYear = startYear + 1;
@@ -109,5 +218,6 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
         sy.setEndDate(java.time.LocalDate.of(endYear, 7, 31));
         sy.setStatus("ACTIVE");
         schoolYearRepository.save(sy);
+        return sy;
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/GetCalendarTemplatesService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/GetCalendarTemplatesService.java
@@ -1,0 +1,83 @@
+package com.didacta.api.application.usecase;
+
+import com.didacta.api.application.dto.CalendarDto;
+import com.didacta.api.application.port.input.GetCalendarTemplatesUseCase;
+import com.didacta.api.application.port.output.CalendarTemplateRepositoryPort;
+import com.didacta.api.domain.exception.EntityNotFoundException;
+import com.didacta.api.domain.model.CalendarTemplate;
+import com.didacta.api.domain.model.CalendarTemplateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetCalendarTemplatesService implements GetCalendarTemplatesUseCase {
+
+    private final CalendarTemplateRepositoryPort templateRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalendarDto.TemplateResponse> listAll() {
+        return templateRepository.findAllActive().stream()
+                .map(this::toTemplateResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalendarDto.TemplateResponse> listByLevel(String level) {
+        return templateRepository.findByApplicableLevelAndAccreditation(level, false).stream()
+                .map(this::toTemplateResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CalendarDto.TemplateDetailResponse getTemplateWithEvents(UUID templateId) {
+        CalendarTemplate template = templateRepository.findById(templateId)
+                .orElseThrow(() -> new EntityNotFoundException("CalendarTemplate", templateId.toString()));
+
+        List<CalendarTemplateEvent> events = templateRepository.findEventsByTemplateId(templateId);
+
+        return CalendarDto.TemplateDetailResponse.builder()
+                .template(toTemplateResponse(template))
+                .events(events.stream().map(this::toTemplateEventResponse).toList())
+                .build();
+    }
+
+    private CalendarDto.TemplateResponse toTemplateResponse(CalendarTemplate t) {
+        return CalendarDto.TemplateResponse.builder()
+                .id(t.getId())
+                .code(t.getCode())
+                .name(t.getName())
+                .description(t.getDescription())
+                .yearLabel(t.getYearLabel())
+                .periodType(t.getPeriodType())
+                .authority(t.getAuthority())
+                .applicableLevels(t.getApplicableLevels())
+                .requiresAccreditation(t.getRequiresAccreditation())
+                .accreditationAuthority(t.getAccreditationAuthority())
+                .startDate(t.getStartDate())
+                .endDate(t.getEndDate())
+                .expectedClassDays(t.getExpectedClassDays())
+                .build();
+    }
+
+    private CalendarDto.TemplateEventResponse toTemplateEventResponse(CalendarTemplateEvent e) {
+        return CalendarDto.TemplateEventResponse.builder()
+                .id(e.getId())
+                .name(e.getName())
+                .eventType(e.getEventType())
+                .startDate(e.getStartDate())
+                .endDate(e.getEndDate())
+                .affectsClasses(e.getAffectsClasses())
+                .affectsStaff(e.getAffectsStaff())
+                .isMandatory(e.getIsMandatory())
+                .sortOrder(e.getSortOrder())
+                .build();
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/GetInstitutionInfoService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/GetInstitutionInfoService.java
@@ -4,11 +4,7 @@ import com.didacta.api.application.dto.OnboardingCommand;
 import com.didacta.api.application.dto.OnboardingResult;
 import com.didacta.api.application.mapper.OnboardingMapper;
 import com.didacta.api.application.port.input.GetInstitutionInfoUseCase;
-import com.didacta.api.application.port.output.CampusRepositoryPort;
-import com.didacta.api.application.port.output.GroupRepositoryPort;
-import com.didacta.api.application.port.output.MembershipRepositoryPort;
-import com.didacta.api.application.port.output.TenantProviderPort;
-import com.didacta.api.application.port.output.UserRepositoryPort;
+import com.didacta.api.application.port.output.*;
 import com.didacta.api.domain.exception.EntityNotFoundException;
 import com.didacta.api.domain.model.*;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +23,7 @@ public class GetInstitutionInfoService implements GetInstitutionInfoUseCase {
     private final MembershipRepositoryPort membershipRepository;
     private final CampusRepositoryPort campusRepository;
     private final GroupRepositoryPort groupRepository;
+    private final AcademicSectionRepositoryPort sectionRepository;
     private final TenantProviderPort tenantProvider;
 
     @Override
@@ -56,7 +53,25 @@ public class GetInstitutionInfoService implements GetInstitutionInfoUseCase {
         boolean hasMultipleCampuses = campus.isPresent() && !"Sede Principal".equals(campus.get().getName());
         String campusName = hasMultipleCampuses ? campus.get().getName() : null;
 
-        return OnboardingMapper.toInstitutionDetails(institution, membership.get(), campusName, hasMultipleCampuses);
+        OnboardingCommand.CreateInstitution details = OnboardingMapper.toInstitutionDetails(
+                institution, membership.get(), campusName, hasMultipleCampuses);
+
+        // Add sections data
+        List<AcademicSection> sections = sectionRepository.findByInstitutionId(institution.getId());
+        if (!sections.isEmpty()) {
+            List<OnboardingCommand.SectionEntry> sectionEntries = sections.stream()
+                    .map(s -> {
+                        OnboardingCommand.SectionEntry entry = new OnboardingCommand.SectionEntry();
+                        entry.setLevel(s.getLevel());
+                        entry.setAccreditationType(s.getAccreditationType());
+                        entry.setAccreditationKey(s.getAccreditationKey());
+                        return entry;
+                    })
+                    .toList();
+            details.setSections(sectionEntries);
+        }
+
+        return details;
     }
 
     @Override
@@ -85,6 +100,23 @@ public class GetInstitutionInfoService implements GetInstitutionInfoUseCase {
                         .name(g.getName())
                         .gradeLevel(g.getGradeLevel())
                         .shift(g.getShift())
+                        .sectionId(g.getSection() != null ? g.getSection().getId() : null)
+                        .build())
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OnboardingResult.AcademicSectionDto> getSections() {
+        String tenantId = tenantProvider.getTenantId();
+        if (tenantId == null) return List.of();
+        UUID institutionId = UUID.fromString(tenantId);
+        return sectionRepository.findByInstitutionId(institutionId).stream()
+                .map(s -> OnboardingResult.AcademicSectionDto.builder()
+                        .id(s.getId())
+                        .level(s.getLevel())
+                        .accreditationType(s.getAccreditationType())
+                        .accreditationKey(s.getAccreditationKey())
                         .build())
                 .toList();
     }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/GetOnboardingStatusService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/GetOnboardingStatusService.java
@@ -44,6 +44,10 @@ public class GetOnboardingStatusService implements GetOnboardingStatusUseCase {
         boolean hasAttendance = false;
         boolean hasCollaborators = false;
 
+        int groupCount = 0;
+        int studentCount = 0;
+        int collaboratorCount = 0;
+
         if (activeMembership.isPresent()) {
             hasInstitution = true;
             Institution institution = activeMembership.get().getInstitution();
@@ -52,19 +56,23 @@ public class GetOnboardingStatusService implements GetOnboardingStatusUseCase {
 
             List<GroupEntity> groups = groupRepository.findByInstitutionId(institutionId);
             hasGroup = !groups.isEmpty();
+            groupCount = groups.size();
 
-            if (hasGroup) {
-                List<Student> students = studentRepository.findByInstitutionId(institutionId);
-                hasStudents = !students.isEmpty();
-                if (hasStudents) {
-                    hasAttendance = attendanceRepository.existsByInstitutionId(institutionId);
-                }
+            List<Student> students = studentRepository.findByInstitutionId(institutionId);
+            hasStudents = !students.isEmpty();
+            studentCount = students.size();
+
+            if (hasStudents) {
+                hasAttendance = attendanceRepository.existsByInstitutionId(institutionId);
             }
 
-            hasCollaborators = !collaboratorRepository.findByInstitutionId(institutionId).isEmpty();
+            List<CollaboratorPreUser> collaborators = collaboratorRepository.findByInstitutionId(institutionId);
+            hasCollaborators = !collaborators.isEmpty();
+            collaboratorCount = collaborators.size();
         }
 
-        String nextStep = resolveNextStep(hasInstitution, hasGroup, hasStudents, hasAttendance);
+        String nextStep = resolveNextStep(hasInstitution);
+        String suggestedNextAction = resolveSuggestedAction(hasGroup, hasStudents, hasAttendance, hasCollaborators);
 
         return OnboardingResult.MeResponse.builder()
                 .user(OnboardingMapper.toUserDto(user))
@@ -77,14 +85,29 @@ public class GetOnboardingStatusService implements GetOnboardingStatusUseCase {
                         .hasCollaborators(hasCollaborators)
                         .nextStep(nextStep)
                         .build())
+                .setupProgress(OnboardingResult.SetupProgress.builder()
+                        .hasGroup(hasGroup)
+                        .hasStudents(hasStudents)
+                        .hasAttendance(hasAttendance)
+                        .hasCollaborators(hasCollaborators)
+                        .groupCount(groupCount)
+                        .studentCount(studentCount)
+                        .collaboratorCount(collaboratorCount)
+                        .suggestedNextAction(suggestedNextAction)
+                        .build())
                 .build();
     }
 
-    private String resolveNextStep(boolean hasInstitution, boolean hasGroup, boolean hasStudents, boolean hasAttendance) {
+    private String resolveNextStep(boolean hasInstitution) {
         if (!hasInstitution) return "STEP_1";
-        if (!hasGroup) return "STEP_2";
-        if (!hasStudents) return "STEP_3";
-        if (!hasAttendance) return "STEP_4";
         return "DONE";
+    }
+
+    private String resolveSuggestedAction(boolean hasGroup, boolean hasStudents, boolean hasAttendance, boolean hasCollaborators) {
+        if (!hasGroup) return "CREATE_GROUP";
+        if (!hasStudents) return "ADD_STUDENTS";
+        if (!hasAttendance) return "TAKE_ATTENDANCE";
+        if (!hasCollaborators) return "INVITE_TEAM";
+        return "ALL_DONE";
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageAcademicSectionsService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageAcademicSectionsService.java
@@ -1,0 +1,56 @@
+package com.didacta.api.application.usecase;
+
+import com.didacta.api.application.dto.AcademicSectionDto;
+import com.didacta.api.application.port.input.ManageAcademicSectionsUseCase;
+import com.didacta.api.application.port.output.AcademicSectionRepositoryPort;
+import com.didacta.api.application.port.output.TenantProviderPort;
+import com.didacta.api.domain.exception.EntityNotFoundException;
+import com.didacta.api.domain.model.AcademicSection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ManageAcademicSectionsService implements ManageAcademicSectionsUseCase {
+
+    private final AcademicSectionRepositoryPort sectionRepository;
+    private final TenantProviderPort tenantProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AcademicSectionDto.Response> listByInstitution() {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        return sectionRepository.findByInstitutionId(institutionId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AcademicSectionDto.Response getById(UUID id) {
+        AcademicSection section = sectionRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("AcademicSection", id.toString()));
+        // Validate tenant ownership
+        UUID institutionId = tenantProvider.getTenantUUID();
+        if (!section.getInstitution().getId().equals(institutionId)) {
+            throw new EntityNotFoundException("AcademicSection", id.toString());
+        }
+        return toResponse(section);
+    }
+
+    private AcademicSectionDto.Response toResponse(AcademicSection section) {
+        return AcademicSectionDto.Response.builder()
+                .id(section.getId())
+                .level(section.getLevel())
+                .accreditationType(section.getAccreditationType())
+                .accreditationKey(section.getAccreditationKey())
+                .name(section.getName())
+                .displayOrder(section.getDisplayOrder())
+                .active(section.getActive())
+                .build();
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageCalendarService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageCalendarService.java
@@ -1,0 +1,209 @@
+package com.didacta.api.application.usecase;
+
+import com.didacta.api.application.dto.CalendarDto;
+import com.didacta.api.application.port.input.ManageCalendarUseCase;
+import com.didacta.api.application.port.output.*;
+import com.didacta.api.domain.exception.DomainException;
+import com.didacta.api.domain.exception.EntityNotFoundException;
+import com.didacta.api.domain.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ManageCalendarService implements ManageCalendarUseCase {
+
+    private final InstitutionCalendarRepositoryPort calendarRepository;
+    private final CalendarEventRepositoryPort eventRepository;
+    private final CalendarTemplateRepositoryPort templateRepository;
+    private final AcademicSectionRepositoryPort sectionRepository;
+    private final InstitutionRepositoryPort institutionRepository;
+    private final SchoolYearRepositoryPort schoolYearRepository;
+    private final TenantProviderPort tenantProvider;
+
+    @Override
+    @Transactional
+    public CalendarDto.CalendarResponse createFromTemplate(CalendarDto.CreateFromTemplate command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        Institution institution = institutionRepository.findById(institutionId)
+                .orElseThrow(() -> new EntityNotFoundException("Institution", institutionId.toString()));
+
+        CalendarTemplate template = templateRepository.findById(command.getTemplateId())
+                .orElseThrow(() -> new EntityNotFoundException("CalendarTemplate", command.getTemplateId().toString()));
+
+        SchoolYear schoolYear = schoolYearRepository.findByInstitutionIdAndStatus(institutionId, "ACTIVE")
+                .orElseThrow(() -> new DomainException("No active school year found"));
+
+        AcademicSection section = null;
+        if (command.getSectionId() != null) {
+            section = sectionRepository.findById(command.getSectionId())
+                    .filter(s -> s.getInstitution().getId().equals(institutionId))
+                    .orElseThrow(() -> new EntityNotFoundException("AcademicSection", command.getSectionId().toString()));
+        }
+
+        // Check if calendar already exists for this section + school year
+        UUID sectionId = section != null ? section.getId() : null;
+        calendarRepository.findByInstitutionIdAndSectionIdAndSchoolYearId(institutionId, sectionId, schoolYear.getId())
+                .ifPresent(existing -> {
+                    throw new DomainException("Calendar already exists for this section and school year");
+                });
+
+        // Create institution calendar
+        InstitutionCalendar calendar = InstitutionCalendar.builder()
+                .institution(institution)
+                .section(section)
+                .schoolYear(schoolYear)
+                .sourceTemplate(template)
+                .name(template.getName())
+                .status("ACTIVE")
+                .build();
+        calendarRepository.save(calendar);
+
+        // Copy template events to calendar events
+        List<CalendarTemplateEvent> templateEvents = templateRepository.findEventsByTemplateId(template.getId());
+        List<CalendarEvent> calendarEvents = templateEvents.stream()
+                .map(te -> CalendarEvent.builder()
+                        .calendar(calendar)
+                        .sourceTemplateEvent(te)
+                        .name(te.getName())
+                        .eventType(te.getEventType())
+                        .startDate(te.getStartDate())
+                        .endDate(te.getEndDate())
+                        .affectsClasses(te.getAffectsClasses())
+                        .affectsStaff(te.getAffectsStaff())
+                        .isFromTemplate(true)
+                        .isDeleted(false)
+                        .build())
+                .toList();
+        eventRepository.saveAll(calendarEvents);
+
+        return toCalendarResponse(calendar);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CalendarDto.CalendarResponse> listByInstitution() {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        return calendarRepository.findByInstitutionId(institutionId).stream()
+                .map(this::toCalendarResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CalendarDto.CalendarDetailResponse getCalendarWithEvents(UUID calendarId) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        InstitutionCalendar calendar = calendarRepository.findById(calendarId)
+                .filter(c -> c.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("InstitutionCalendar", calendarId.toString()));
+
+        List<CalendarEvent> events = eventRepository.findByCalendarId(calendarId);
+
+        return CalendarDto.CalendarDetailResponse.builder()
+                .calendar(toCalendarResponse(calendar))
+                .events(events.stream().map(this::toEventResponse).toList())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public CalendarDto.EventResponse addEvent(UUID calendarId, CalendarDto.CreateEvent command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        InstitutionCalendar calendar = calendarRepository.findById(calendarId)
+                .filter(c -> c.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("InstitutionCalendar", calendarId.toString()));
+
+        CalendarEvent event = CalendarEvent.builder()
+                .calendar(calendar)
+                .name(command.getName())
+                .eventType(command.getEventType())
+                .startDate(command.getStartDate())
+                .endDate(command.getEndDate())
+                .affectsClasses(command.getAffectsClasses() != null ? command.getAffectsClasses() : true)
+                .affectsStaff(command.getAffectsStaff() != null ? command.getAffectsStaff() : false)
+                .isFromTemplate(false)
+                .isDeleted(false)
+                .notes(command.getNotes())
+                .build();
+        eventRepository.save(event);
+
+        return toEventResponse(event);
+    }
+
+    @Override
+    @Transactional
+    public CalendarDto.EventResponse updateEvent(UUID calendarId, UUID eventId, CalendarDto.UpdateEvent command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        // Validate calendar ownership
+        calendarRepository.findById(calendarId)
+                .filter(c -> c.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("InstitutionCalendar", calendarId.toString()));
+
+        CalendarEvent event = eventRepository.findById(eventId)
+                .filter(e -> e.getCalendar().getId().equals(calendarId))
+                .orElseThrow(() -> new EntityNotFoundException("CalendarEvent", eventId.toString()));
+
+        if (command.getName() != null) event.setName(command.getName());
+        if (command.getEventType() != null) event.setEventType(command.getEventType());
+        if (command.getStartDate() != null) event.setStartDate(command.getStartDate());
+        if (command.getEndDate() != null) event.setEndDate(command.getEndDate());
+        if (command.getAffectsClasses() != null) event.setAffectsClasses(command.getAffectsClasses());
+        if (command.getAffectsStaff() != null) event.setAffectsStaff(command.getAffectsStaff());
+        if (command.getNotes() != null) event.setNotes(command.getNotes());
+
+        eventRepository.save(event);
+        return toEventResponse(event);
+    }
+
+    @Override
+    @Transactional
+    public void softDeleteEvent(UUID calendarId, UUID eventId) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        calendarRepository.findById(calendarId)
+                .filter(c -> c.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("InstitutionCalendar", calendarId.toString()));
+
+        CalendarEvent event = eventRepository.findById(eventId)
+                .filter(e -> e.getCalendar().getId().equals(calendarId))
+                .orElseThrow(() -> new EntityNotFoundException("CalendarEvent", eventId.toString()));
+
+        event.setIsDeleted(true);
+        eventRepository.save(event);
+    }
+
+    private CalendarDto.CalendarResponse toCalendarResponse(InstitutionCalendar c) {
+        return CalendarDto.CalendarResponse.builder()
+                .id(c.getId())
+                .sectionId(c.getSection() != null ? c.getSection().getId() : null)
+                .sectionLevel(c.getSection() != null ? c.getSection().getLevel() : null)
+                .schoolYearId(c.getSchoolYear().getId())
+                .sourceTemplateId(c.getSourceTemplate() != null ? c.getSourceTemplate().getId() : null)
+                .name(c.getName())
+                .status(c.getStatus())
+                .build();
+    }
+
+    private CalendarDto.EventResponse toEventResponse(CalendarEvent e) {
+        return CalendarDto.EventResponse.builder()
+                .id(e.getId())
+                .name(e.getName())
+                .eventType(e.getEventType())
+                .startDate(e.getStartDate())
+                .endDate(e.getEndDate())
+                .affectsClasses(e.getAffectsClasses())
+                .affectsStaff(e.getAffectsStaff())
+                .isFromTemplate(e.getIsFromTemplate())
+                .isDeleted(e.getIsDeleted())
+                .notes(e.getNotes())
+                .build();
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/AcademicSection.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/AcademicSection.java
@@ -1,0 +1,49 @@
+package com.didacta.api.domain.model;
+
+import com.didacta.api.domain.common.BaseTenantEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "academic_sections")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AcademicSection extends BaseTenantEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid7")
+    @org.hibernate.annotations.GenericGenerator(name = "uuid7", type = com.didacta.api.domain.common.UuidV7Generator.class)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id", nullable = false)
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private Institution institution;
+
+    @Column(nullable = false, length = 30)
+    private String level;
+
+    @Column(name = "accreditation_type", nullable = false, length = 30)
+    private String accreditationType;
+
+    @Column(name = "accreditation_key", length = 100)
+    private String accreditationKey;
+
+    @Column(length = 100)
+    private String name;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @Column(nullable = false)
+    private Boolean active;
+}

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarEvent.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarEvent.java
@@ -1,0 +1,64 @@
+package com.didacta.api.domain.model;
+
+import com.didacta.api.domain.common.BaseTenantEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "calendar_events")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarEvent extends BaseTenantEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid7")
+    @org.hibernate.annotations.GenericGenerator(name = "uuid7", type = com.didacta.api.domain.common.UuidV7Generator.class)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "calendar_id", nullable = false)
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private InstitutionCalendar calendar;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_template_event_id")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private CalendarTemplateEvent sourceTemplateEvent;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "event_type", nullable = false, length = 30)
+    private String eventType;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "affects_classes", nullable = false)
+    private Boolean affectsClasses;
+
+    @Column(name = "affects_staff", nullable = false)
+    private Boolean affectsStaff;
+
+    @Column(name = "is_from_template", nullable = false)
+    private Boolean isFromTemplate;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+}

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarTemplate.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarTemplate.java
@@ -1,0 +1,71 @@
+package com.didacta.api.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "calendar_templates")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarTemplate {
+
+    @Id
+    @GeneratedValue(generator = "uuid7")
+    @org.hibernate.annotations.GenericGenerator(name = "uuid7", type = com.didacta.api.domain.common.UuidV7Generator.class)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "year_label", nullable = false, length = 20)
+    private String yearLabel;
+
+    @Column(name = "period_type", nullable = false, length = 20)
+    private String periodType;
+
+    @Column(nullable = false, length = 30)
+    private String authority;
+
+    @Column(name = "applicable_levels", columnDefinition = "TEXT")
+    private String applicableLevels;
+
+    @Column(name = "requires_accreditation", nullable = false)
+    private Boolean requiresAccreditation;
+
+    @Column(name = "accreditation_authority", length = 30)
+    private String accreditationAuthority;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "expected_class_days")
+    private Integer expectedClassDays;
+
+    @Column(nullable = false)
+    private Boolean active;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarTemplateEvent.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/CalendarTemplateEvent.java
@@ -1,0 +1,61 @@
+package com.didacta.api.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "calendar_template_events")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarTemplateEvent {
+
+    @Id
+    @GeneratedValue(generator = "uuid7")
+    @org.hibernate.annotations.GenericGenerator(name = "uuid7", type = com.didacta.api.domain.common.UuidV7Generator.class)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id", nullable = false)
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private CalendarTemplate template;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "event_type", nullable = false, length = 30)
+    private String eventType;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "affects_classes", nullable = false)
+    private Boolean affectsClasses;
+
+    @Column(name = "affects_staff", nullable = false)
+    private Boolean affectsStaff;
+
+    @Column(name = "is_mandatory", nullable = false)
+    private Boolean isMandatory;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/GroupEntity.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/GroupEntity.java
@@ -31,6 +31,11 @@ public class GroupEntity {
     @com.fasterxml.jackson.annotation.JsonIgnore
     private Campus campus;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private AcademicSection section;
+
     @Column(nullable = false)
     private String name;
 

--- a/didacta-api/src/main/java/com/didacta/api/domain/model/InstitutionCalendar.java
+++ b/didacta-api/src/main/java/com/didacta/api/domain/model/InstitutionCalendar.java
@@ -1,0 +1,52 @@
+package com.didacta.api.domain.model;
+
+import com.didacta.api.domain.common.BaseTenantEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "institution_calendars")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InstitutionCalendar extends BaseTenantEntity {
+
+    @Id
+    @GeneratedValue(generator = "uuid7")
+    @org.hibernate.annotations.GenericGenerator(name = "uuid7", type = com.didacta.api.domain.common.UuidV7Generator.class)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "institution_id", nullable = false)
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private Institution institution;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private AcademicSection section;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_year_id", nullable = false)
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private SchoolYear schoolYear;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_template_id")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private CalendarTemplate sourceTemplate;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/AcademicSectionController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/AcademicSectionController.java
@@ -1,0 +1,28 @@
+package com.didacta.api.infrastructure.adapter.input.web.controller;
+
+import com.didacta.api.application.dto.AcademicSectionDto;
+import com.didacta.api.application.port.input.ManageAcademicSectionsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/sections")
+@RequiredArgsConstructor
+public class AcademicSectionController {
+
+    private final ManageAcademicSectionsUseCase manageSections;
+
+    @GetMapping
+    public ResponseEntity<List<AcademicSectionDto.Response>> listSections() {
+        return ResponseEntity.ok(manageSections.listByInstitution());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AcademicSectionDto.Response> getSection(@PathVariable UUID id) {
+        return ResponseEntity.ok(manageSections.getById(id));
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/CalendarController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/CalendarController.java
@@ -1,0 +1,58 @@
+package com.didacta.api.infrastructure.adapter.input.web.controller;
+
+import com.didacta.api.application.dto.CalendarDto;
+import com.didacta.api.application.port.input.ManageCalendarUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/calendars")
+@RequiredArgsConstructor
+public class CalendarController {
+
+    private final ManageCalendarUseCase manageCalendar;
+
+    @PostMapping
+    public ResponseEntity<CalendarDto.CalendarResponse> createFromTemplate(
+            @Valid @RequestBody CalendarDto.CreateFromTemplate command) {
+        return ResponseEntity.ok(manageCalendar.createFromTemplate(command));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CalendarDto.CalendarResponse>> listCalendars() {
+        return ResponseEntity.ok(manageCalendar.listByInstitution());
+    }
+
+    @GetMapping("/{calendarId}")
+    public ResponseEntity<CalendarDto.CalendarDetailResponse> getCalendar(@PathVariable UUID calendarId) {
+        return ResponseEntity.ok(manageCalendar.getCalendarWithEvents(calendarId));
+    }
+
+    @PostMapping("/{calendarId}/events")
+    public ResponseEntity<CalendarDto.EventResponse> addEvent(
+            @PathVariable UUID calendarId,
+            @Valid @RequestBody CalendarDto.CreateEvent command) {
+        return ResponseEntity.ok(manageCalendar.addEvent(calendarId, command));
+    }
+
+    @PatchMapping("/{calendarId}/events/{eventId}")
+    public ResponseEntity<CalendarDto.EventResponse> updateEvent(
+            @PathVariable UUID calendarId,
+            @PathVariable UUID eventId,
+            @Valid @RequestBody CalendarDto.UpdateEvent command) {
+        return ResponseEntity.ok(manageCalendar.updateEvent(calendarId, eventId, command));
+    }
+
+    @DeleteMapping("/{calendarId}/events/{eventId}")
+    public ResponseEntity<Void> deleteEvent(
+            @PathVariable UUID calendarId,
+            @PathVariable UUID eventId) {
+        manageCalendar.softDeleteEvent(calendarId, eventId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/CalendarTemplateController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/CalendarTemplateController.java
@@ -1,0 +1,32 @@
+package com.didacta.api.infrastructure.adapter.input.web.controller;
+
+import com.didacta.api.application.dto.CalendarDto;
+import com.didacta.api.application.port.input.GetCalendarTemplatesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/catalogs/calendar-templates")
+@RequiredArgsConstructor
+public class CalendarTemplateController {
+
+    private final GetCalendarTemplatesUseCase getTemplates;
+
+    @GetMapping
+    public ResponseEntity<List<CalendarDto.TemplateResponse>> listTemplates(
+            @RequestParam(required = false) String level) {
+        if (level != null && !level.isBlank()) {
+            return ResponseEntity.ok(getTemplates.listByLevel(level));
+        }
+        return ResponseEntity.ok(getTemplates.listAll());
+    }
+
+    @GetMapping("/{templateId}")
+    public ResponseEntity<CalendarDto.TemplateDetailResponse> getTemplate(@PathVariable UUID templateId) {
+        return ResponseEntity.ok(getTemplates.getTemplateWithEvents(templateId));
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/OnboardingController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/OnboardingController.java
@@ -90,4 +90,9 @@ public class OnboardingController {
     public OnboardingCommand.CreateInstitution getInstitutionDetails(@AuthenticationPrincipal Jwt jwt) {
         return getInstitutionInfo.getDetails(jwt.getSubject());
     }
+
+    @GetMapping("/onboarding/sections")
+    public List<OnboardingResult.AcademicSectionDto> getSections() {
+        return getInstitutionInfo.getSections();
+    }
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/AcademicSectionPersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/AcademicSectionPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.adapter;
+
+import com.didacta.api.application.port.output.AcademicSectionRepositoryPort;
+import com.didacta.api.domain.model.AcademicSection;
+import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaAcademicSectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AcademicSectionPersistenceAdapter implements AcademicSectionRepositoryPort {
+
+    private final JpaAcademicSectionRepository jpaRepo;
+
+    @Override
+    public AcademicSection save(AcademicSection section) {
+        return jpaRepo.save(section);
+    }
+
+    @Override
+    public Optional<AcademicSection> findById(UUID id) {
+        return jpaRepo.findById(id);
+    }
+
+    @Override
+    public List<AcademicSection> findByInstitutionId(UUID institutionId) {
+        return jpaRepo.findByInstitutionIdOrderByDisplayOrderAsc(institutionId);
+    }
+
+    @Override
+    public Optional<AcademicSection> findByInstitutionIdAndLevel(UUID institutionId, String level) {
+        return jpaRepo.findByInstitutionIdAndLevel(institutionId, level);
+    }
+
+    @Override
+    public void deleteByInstitutionId(UUID institutionId) {
+        jpaRepo.deleteByInstitutionId(institutionId);
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarEventPersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarEventPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.adapter;
+
+import com.didacta.api.application.port.output.CalendarEventRepositoryPort;
+import com.didacta.api.domain.model.CalendarEvent;
+import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaCalendarEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarEventPersistenceAdapter implements CalendarEventRepositoryPort {
+
+    private final JpaCalendarEventRepository jpaRepo;
+
+    @Override
+    public CalendarEvent save(CalendarEvent event) {
+        return jpaRepo.save(event);
+    }
+
+    @Override
+    public List<CalendarEvent> saveAll(List<CalendarEvent> events) {
+        return jpaRepo.saveAll(events);
+    }
+
+    @Override
+    public Optional<CalendarEvent> findById(UUID id) {
+        return jpaRepo.findById(id);
+    }
+
+    @Override
+    public List<CalendarEvent> findByCalendarId(UUID calendarId) {
+        return jpaRepo.findByCalendarIdOrderByStartDateAsc(calendarId);
+    }
+
+    @Override
+    public void deleteByCalendarId(UUID calendarId) {
+        jpaRepo.deleteByCalendarId(calendarId);
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarTemplatePersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarTemplatePersistenceAdapter.java
@@ -1,0 +1,41 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.adapter;
+
+import com.didacta.api.application.port.output.CalendarTemplateRepositoryPort;
+import com.didacta.api.domain.model.CalendarTemplate;
+import com.didacta.api.domain.model.CalendarTemplateEvent;
+import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaCalendarTemplateEventRepository;
+import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaCalendarTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarTemplatePersistenceAdapter implements CalendarTemplateRepositoryPort {
+
+    private final JpaCalendarTemplateRepository templateRepo;
+    private final JpaCalendarTemplateEventRepository eventRepo;
+
+    @Override
+    public List<CalendarTemplate> findAllActive() {
+        return templateRepo.findByActiveTrue();
+    }
+
+    @Override
+    public Optional<CalendarTemplate> findById(UUID id) {
+        return templateRepo.findById(id);
+    }
+
+    @Override
+    public List<CalendarTemplate> findByApplicableLevelAndAccreditation(String level, boolean requiresAccreditation) {
+        return templateRepo.findByApplicableLevelAndAccreditation(level, requiresAccreditation);
+    }
+
+    @Override
+    public List<CalendarTemplateEvent> findEventsByTemplateId(UUID templateId) {
+        return eventRepo.findByTemplateIdOrderBySortOrderAsc(templateId);
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/InstitutionCalendarPersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/InstitutionCalendarPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.adapter;
+
+import com.didacta.api.application.port.output.InstitutionCalendarRepositoryPort;
+import com.didacta.api.domain.model.InstitutionCalendar;
+import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaInstitutionCalendarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class InstitutionCalendarPersistenceAdapter implements InstitutionCalendarRepositoryPort {
+
+    private final JpaInstitutionCalendarRepository jpaRepo;
+
+    @Override
+    public InstitutionCalendar save(InstitutionCalendar calendar) {
+        return jpaRepo.save(calendar);
+    }
+
+    @Override
+    public Optional<InstitutionCalendar> findById(UUID id) {
+        return jpaRepo.findById(id);
+    }
+
+    @Override
+    public List<InstitutionCalendar> findByInstitutionId(UUID institutionId) {
+        return jpaRepo.findByInstitutionId(institutionId);
+    }
+
+    @Override
+    public Optional<InstitutionCalendar> findByInstitutionIdAndSectionIdAndSchoolYearId(UUID institutionId, UUID sectionId, UUID schoolYearId) {
+        return jpaRepo.findByInstitutionIdAndSectionIdAndSchoolYearId(institutionId, sectionId, schoolYearId);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRepo.deleteById(id);
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaAcademicSectionRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaAcademicSectionRepository.java
@@ -1,0 +1,16 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.repository;
+
+import com.didacta.api.domain.model.AcademicSection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaAcademicSectionRepository extends JpaRepository<AcademicSection, UUID> {
+    List<AcademicSection> findByInstitutionIdOrderByDisplayOrderAsc(UUID institutionId);
+    Optional<AcademicSection> findByInstitutionIdAndLevel(UUID institutionId, String level);
+    void deleteByInstitutionId(UUID institutionId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarEventRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarEventRepository.java
@@ -1,0 +1,14 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.repository;
+
+import com.didacta.api.domain.model.CalendarEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaCalendarEventRepository extends JpaRepository<CalendarEvent, UUID> {
+    List<CalendarEvent> findByCalendarIdOrderByStartDateAsc(UUID calendarId);
+    void deleteByCalendarId(UUID calendarId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateEventRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateEventRepository.java
@@ -1,0 +1,13 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.repository;
+
+import com.didacta.api.domain.model.CalendarTemplateEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaCalendarTemplateEventRepository extends JpaRepository<CalendarTemplateEvent, UUID> {
+    List<CalendarTemplateEvent> findByTemplateIdOrderBySortOrderAsc(UUID templateId);
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateRepository.java
@@ -1,0 +1,21 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.repository;
+
+import com.didacta.api.domain.model.CalendarTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaCalendarTemplateRepository extends JpaRepository<CalendarTemplate, UUID> {
+    List<CalendarTemplate> findByActiveTrue();
+
+    @Query("SELECT ct FROM CalendarTemplate ct WHERE ct.active = true AND ct.applicableLevels LIKE %:level%")
+    List<CalendarTemplate> findByApplicableLevel(@Param("level") String level);
+
+    @Query("SELECT ct FROM CalendarTemplate ct WHERE ct.active = true AND ct.applicableLevels LIKE %:level% AND ct.requiresAccreditation = :requiresAccreditation")
+    List<CalendarTemplate> findByApplicableLevelAndAccreditation(@Param("level") String level, @Param("requiresAccreditation") boolean requiresAccreditation);
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaInstitutionCalendarRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaInstitutionCalendarRepository.java
@@ -1,0 +1,15 @@
+package com.didacta.api.infrastructure.adapter.output.persistence.repository;
+
+import com.didacta.api.domain.model.InstitutionCalendar;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaInstitutionCalendarRepository extends JpaRepository<InstitutionCalendar, UUID> {
+    List<InstitutionCalendar> findByInstitutionId(UUID institutionId);
+    Optional<InstitutionCalendar> findByInstitutionIdAndSectionIdAndSchoolYearId(UUID institutionId, UUID sectionId, UUID schoolYearId);
+}

--- a/didacta-api/src/main/resources/db/migration/V6__academic_sections_and_calendars.sql
+++ b/didacta-api/src/main/resources/db/migration/V6__academic_sections_and_calendars.sql
@@ -1,0 +1,196 @@
+-- =============================================
+-- V6: Academic Sections and Calendar System
+-- =============================================
+
+-- 1. Academic Sections (nivel educativo con incorporacion)
+CREATE TABLE academic_sections (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    institution_id UUID NOT NULL REFERENCES institution(id),
+    level VARCHAR(30) NOT NULL,
+    accreditation_type VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    accreditation_key VARCHAR(100),
+    name VARCHAR(100),
+    display_order INT NOT NULL DEFAULT 0,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    tenant_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    created_by VARCHAR(255)
+);
+CREATE INDEX idx_academic_section_tenant ON academic_sections(tenant_id);
+CREATE UNIQUE INDEX idx_academic_section_inst_level ON academic_sections(institution_id, level);
+
+-- 2. Add section_id to groups (nullable for backward compat)
+ALTER TABLE group_entity ADD COLUMN section_id UUID REFERENCES academic_sections(id);
+
+-- 3. Calendar templates (global, NOT tenant-scoped)
+CREATE TABLE calendar_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code VARCHAR(50) NOT NULL UNIQUE,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    year_label VARCHAR(20) NOT NULL,
+    period_type VARCHAR(20) NOT NULL DEFAULT 'ANNUAL',
+    authority VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    applicable_levels TEXT,
+    requires_accreditation BOOLEAN NOT NULL DEFAULT FALSE,
+    accreditation_authority VARCHAR(30),
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    expected_class_days INT,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 4. Calendar template events
+CREATE TABLE calendar_template_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES calendar_templates(id) ON DELETE CASCADE,
+    name VARCHAR(200) NOT NULL,
+    event_type VARCHAR(30) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    affects_classes BOOLEAN NOT NULL DEFAULT TRUE,
+    affects_staff BOOLEAN NOT NULL DEFAULT FALSE,
+    is_mandatory BOOLEAN NOT NULL DEFAULT FALSE,
+    sort_order INT DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_template_event_template ON calendar_template_events(template_id);
+
+-- 5. Institution calendars (tenant-scoped, editable copy)
+CREATE TABLE institution_calendars (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    institution_id UUID NOT NULL REFERENCES institution(id),
+    section_id UUID REFERENCES academic_sections(id),
+    school_year_id UUID NOT NULL REFERENCES school_year(id),
+    source_template_id UUID REFERENCES calendar_templates(id),
+    name VARCHAR(200) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    tenant_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    created_by VARCHAR(255),
+    CONSTRAINT uq_inst_cal_section_year UNIQUE (institution_id, section_id, school_year_id)
+);
+CREATE INDEX idx_inst_calendar_tenant ON institution_calendars(tenant_id);
+
+-- 6. Calendar events (tenant-scoped, editable)
+CREATE TABLE calendar_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    calendar_id UUID NOT NULL REFERENCES institution_calendars(id) ON DELETE CASCADE,
+    source_template_event_id UUID REFERENCES calendar_template_events(id),
+    name VARCHAR(200) NOT NULL,
+    event_type VARCHAR(30) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    affects_classes BOOLEAN NOT NULL DEFAULT TRUE,
+    affects_staff BOOLEAN NOT NULL DEFAULT FALSE,
+    is_from_template BOOLEAN NOT NULL DEFAULT TRUE,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    notes TEXT,
+    tenant_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ,
+    created_by VARCHAR(255)
+);
+CREATE INDEX idx_cal_event_calendar ON calendar_events(calendar_id);
+CREATE INDEX idx_cal_event_tenant ON calendar_events(tenant_id);
+CREATE INDEX idx_cal_event_dates ON calendar_events(start_date, end_date);
+
+-- 7. Add has_sep_incorporation to institution
+ALTER TABLE institution ADD COLUMN IF NOT EXISTS has_sep_incorporation BOOLEAN DEFAULT FALSE;
+
+-- 8. Migrate existing data: create academic sections for existing institutions
+INSERT INTO academic_sections (institution_id, level, accreditation_type, name, display_order, tenant_id, created_at)
+SELECT i.id, i.main_level, 'NONE', NULL, 0, i.id::text, NOW()
+FROM institution i
+WHERE i.main_level IS NOT NULL
+ON CONFLICT (institution_id, level) DO NOTHING;
+
+-- =============================================
+-- 9. Seed calendar templates
+-- =============================================
+
+-- Template: SEP Educacion Basica 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000001', 'SEP_BASICA_2025_2026', 'Calendario SEP Educacion Basica 2025-2026', 'Calendario oficial de la SEP para educacion basica. 185 dias efectivos.', '2025-2026', 'ANNUAL', 'SEP', 'PREESCOLAR,PRIMARIA,SECUNDARIA', TRUE, 'SEP_RVOE', '2025-09-01', '2026-07-15', 185);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000001', 'Fase Intensiva CTE', 'CTE', '2025-08-25', '2025-08-29', TRUE, FALSE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000001', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 1a sesion ordinaria', 'CTE', '2025-09-26', '2025-09-26', TRUE, FALSE, TRUE, 11),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 2a sesion ordinaria', 'CTE', '2025-10-31', '2025-10-31', TRUE, FALSE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000001', 'Registro calificaciones - Primer periodo', 'ADMIN', '2025-11-14', '2025-11-14', FALSE, FALSE, TRUE, 13),
+('a1000000-0000-0000-0000-000000000001', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 14),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 3a sesion ordinaria', 'CTE', '2025-11-28', '2025-11-28', TRUE, FALSE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000001', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000001', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000001', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 18),
+('a1000000-0000-0000-0000-000000000001', 'Taller intensivo - Direccion', 'CTE', '2026-01-07', '2026-01-07', TRUE, FALSE, TRUE, 19),
+('a1000000-0000-0000-0000-000000000001', 'Taller intensivo - Docentes', 'CTE', '2026-01-08', '2026-01-09', TRUE, FALSE, TRUE, 20),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 4a sesion ordinaria', 'CTE', '2026-01-30', '2026-01-30', TRUE, FALSE, TRUE, 21),
+('a1000000-0000-0000-0000-000000000001', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-03', '2026-02-03', TRUE, TRUE, TRUE, 22),
+('a1000000-0000-0000-0000-000000000001', 'Preinscripciones 2026-2027', 'ADMIN', '2026-02-03', '2026-02-13', FALSE, FALSE, FALSE, 23),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 5a sesion ordinaria', 'CTE', '2026-02-27', '2026-02-27', TRUE, FALSE, TRUE, 24),
+('a1000000-0000-0000-0000-000000000001', 'Registro calificaciones - Segundo periodo', 'ADMIN', '2026-03-13', '2026-03-13', FALSE, FALSE, TRUE, 25),
+('a1000000-0000-0000-0000-000000000001', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 26),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 6a sesion ordinaria', 'CTE', '2026-03-27', '2026-03-27', TRUE, FALSE, TRUE, 27),
+('a1000000-0000-0000-0000-000000000001', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, TRUE, 28),
+('a1000000-0000-0000-0000-000000000001', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 29),
+('a1000000-0000-0000-0000-000000000001', 'Batalla de Puebla', 'HOLIDAY', '2026-05-05', '2026-05-05', TRUE, TRUE, TRUE, 30),
+('a1000000-0000-0000-0000-000000000001', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, TRUE, TRUE, 31),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 7a sesion ordinaria', 'CTE', '2026-05-29', '2026-05-29', TRUE, FALSE, TRUE, 32),
+('a1000000-0000-0000-0000-000000000001', 'CTE - 8a sesion ordinaria', 'CTE', '2026-06-26', '2026-06-26', TRUE, FALSE, TRUE, 33),
+('a1000000-0000-0000-0000-000000000001', 'Registro calificaciones - Tercer periodo', 'ADMIN', '2026-07-03', '2026-07-03', FALSE, FALSE, TRUE, 34),
+('a1000000-0000-0000-0000-000000000001', 'Vacaciones de verano', 'VACATION', '2026-07-16', '2026-08-31', TRUE, TRUE, FALSE, 35);
+
+-- Template: Guarderia Privada 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000002', 'GUARDERIA_PRIVADA_2025_2026', 'Calendario Guarderia Privada 2025-2026', 'Calendario para guarderias y maternales privados sin incorporacion SEP.', '2025-2026', 'ANNUAL', 'NONE', 'MATERNAL', FALSE, NULL, '2025-08-18', '2026-08-14', 240);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000002', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000002', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 11),
+('a1000000-0000-0000-0000-000000000002', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000002', 'Dia de la Virgen de Guadalupe', 'SUSPENSION', '2025-12-12', '2025-12-12', TRUE, FALSE, FALSE, 13),
+('a1000000-0000-0000-0000-000000000002', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-06', TRUE, TRUE, FALSE, 14),
+('a1000000-0000-0000-0000-000000000002', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000002', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000002', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000002', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 18),
+('a1000000-0000-0000-0000-000000000002', 'Semana Santa', 'VACATION', '2026-04-02', '2026-04-03', TRUE, TRUE, FALSE, 19),
+('a1000000-0000-0000-0000-000000000002', 'Dia del Nino', 'SUSPENSION', '2026-04-30', '2026-04-30', TRUE, FALSE, FALSE, 20),
+('a1000000-0000-0000-0000-000000000002', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 21);
+
+-- Template: Preescolar Privado Flexible 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000003', 'PREESCOLAR_PRIVADO_2025_2026', 'Calendario Preescolar Privado 2025-2026', 'Calendario para preescolares privados sin incorporacion SEP. Estructura similar a SEP pero flexible.', '2025-2026', 'ANNUAL', 'NONE', 'PREESCOLAR', FALSE, NULL, '2025-08-25', '2026-07-15', 190);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000003', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000003', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 11),
+('a1000000-0000-0000-0000-000000000003', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000003', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, FALSE, 13),
+('a1000000-0000-0000-0000-000000000003', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 14),
+('a1000000-0000-0000-0000-000000000003', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000003', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000003', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000003', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, FALSE, 18),
+('a1000000-0000-0000-0000-000000000003', 'Dia del Nino', 'SUSPENSION', '2026-04-30', '2026-04-30', TRUE, FALSE, FALSE, 19),
+('a1000000-0000-0000-0000-000000000003', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 20),
+('a1000000-0000-0000-0000-000000000003', 'Batalla de Puebla', 'SUSPENSION', '2026-05-05', '2026-05-05', TRUE, FALSE, FALSE, 21),
+('a1000000-0000-0000-0000-000000000003', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, FALSE, FALSE, 22);
+
+-- Template: Empresarial 2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000004', 'EMPRESARIAL_2026', 'Calendario Laboral Mexico 2026', 'Calendario laboral estandar. Solo dias festivos de ley. Totalmente configurable.', '2026', 'ANNUAL', 'NONE', 'EMPRESARIAL', FALSE, NULL, '2026-01-01', '2026-12-31', 250);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000004', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000004', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 2),
+('a1000000-0000-0000-0000-000000000004', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 3),
+('a1000000-0000-0000-0000-000000000004', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 4),
+('a1000000-0000-0000-0000-000000000004', 'Dia de la Independencia', 'HOLIDAY', '2026-09-16', '2026-09-16', TRUE, TRUE, TRUE, 5),
+('a1000000-0000-0000-0000-000000000004', 'Revolucion Mexicana', 'HOLIDAY', '2026-11-16', '2026-11-16', TRUE, TRUE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000004', 'Navidad', 'HOLIDAY', '2026-12-25', '2026-12-25', TRUE, TRUE, TRUE, 7);

--- a/didacta-web/src/App.tsx
+++ b/didacta-web/src/App.tsx
@@ -5,10 +5,7 @@ import DashboardLayout from './views/DashboardLayout';
 import AuthGuard from './components/AuthGuard';
 import Step0Welcome from './views/onboarding/Step0Welcome';
 import Step1Institution from './views/onboarding/Step1Institution';
-import Step2Group from './views/onboarding/Step2Group';
-import Step3Students from './views/onboarding/Step3Students';
-import Step4Attendance from './views/onboarding/Step4Attendance';
-import Step5Collaborator from './views/onboarding/Step5Collaborator';
+import Step2InviteUser from './views/onboarding/Step2InviteUser';
 
 export default function App() {
   return (
@@ -25,10 +22,7 @@ export default function App() {
 
           <Route path="/onboarding/step-0" element={<Step0Welcome />} />
           <Route path="/onboarding/step-1" element={<Step1Institution />} />
-          <Route path="/onboarding/step-2" element={<Step2Group />} />
-          <Route path="/onboarding/step-3" element={<Step3Students />} />
-          <Route path="/onboarding/step-4" element={<Step4Attendance />} />
-          <Route path="/onboarding/step-5" element={<Step5Collaborator />} />
+          <Route path="/onboarding/step-2" element={<Step2InviteUser />} />
         </Route>
 
         {/* Default Redirect */}

--- a/didacta-web/src/components/AuthGuard.tsx
+++ b/didacta-web/src/components/AuthGuard.tsx
@@ -15,17 +15,17 @@ export default function AuthGuard({ children }: AuthGuardProps) {
     const navigate = useNavigate();
     const location = useLocation();
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<any>(null);
-    const [statusMessage, setStatusMessage] = useState("Verificando sesión...");
+    const [error, setError] = useState<string | null>(null);
+    const [statusMessage, setStatusMessage] = useState("Verificando sesion...");
 
     // State for user data
-    const [userData, setUserData] = useState<any>(null);
+    const [userData, setUserData] = useState<Record<string, unknown> | null>(null);
 
     // EFFECT 1: INITIAL LOAD (Runs once)
     useEffect(() => {
         const initAuth = async () => {
             if (!keycloak.authenticated) {
-                setStatusMessage("Redirigiendo a inicio de sesión...");
+                setStatusMessage("Redirigiendo a inicio de sesion...");
                 keycloak.login();
                 return;
             }
@@ -38,7 +38,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
                     "Creando tu cuenta institucional segura...",
                     "Estamos configurando tu perfil docente...",
                     "Preparando tu entorno de trabajo...",
-                    "¡Todo listo! Ingresando a Didacta..."
+                    "Todo listo! Ingresando a Didacta..."
                 ];
                 for (const msg of messages) {
                     setStatusMessage(msg);
@@ -65,7 +65,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
                         attempts++;
                         console.warn(`Auth Check attempt ${attempts} failed`);
                         if (attempts >= maxAttempts) {
-                            setError(retryErr);
+                            setError('No pudimos verificar tu estado. Intenta recargar.');
                             break;
                         }
                         await new Promise(resolve => setTimeout(resolve, 2000));
@@ -92,30 +92,30 @@ export default function AuthGuard({ children }: AuthGuardProps) {
                 }
                 const freshData = res.data;
                 const freshStep = freshData.onboarding.nextStep;
+                const hasInstitution = !!freshData.tenant?.institutionId;
 
                 if (freshStep === 'DONE') {
-                    if (currentPath.startsWith('/onboarding')) {
+                    // Allow step-2 (invite) even when DONE, as long as user has institution
+                    if (currentPath === '/onboarding/step-2' && hasInstitution) {
+                        return;
+                    }
+                    // Redirect away from step-0 and step-1 if already DONE
+                    if (currentPath === '/onboarding/step-0' || currentPath === '/onboarding/step-1') {
                         navigate('/dashboard');
                     }
+                } else if (freshStep === 'STEP_1') {
+                    // User hasn't created institution yet
+                    if (!currentPath.startsWith('/onboarding')) {
+                        navigate('/onboarding/step-0');
+                    }
+                    // Allow step-0 and step-1, block step-2 (no institution yet)
+                    if (currentPath === '/onboarding/step-2') {
+                        navigate('/onboarding/step-1');
+                    }
                 } else {
-                    const stepOrder: Record<string, number> = {
-                        'STEP_0': 0,
-                        'STEP_1': 1,
-                        'STEP_2': 2,
-                        'STEP_3': 3,
-                        'STEP_4': 4,
-                        'STEP_5': 5,
-                    };
-                    const maxStep = stepOrder[freshStep] ?? 0;
-                    const currentStep = pathToStep(currentPath);
-
-                    if (currentStep >= 0) {
-                        // Allow step-0 (welcome) always; guard only steps beyond maxStep
-                        if (currentStep > 0 && currentStep > maxStep) {
-                            navigate(stepToPath(freshStep));
-                        }
-                    } else {
-                        navigate(stepToPath(freshStep));
+                    // For any other step, if user is not in onboarding, redirect to step-0
+                    if (!currentPath.startsWith('/onboarding') && !currentPath.startsWith('/dashboard')) {
+                        navigate('/onboarding/step-0');
                     }
                 }
             } catch (e) {
@@ -127,28 +127,6 @@ export default function AuthGuard({ children }: AuthGuardProps) {
 
     }, [location, userData, loading, navigate]);
 
-    function stepToPath(step: string) {
-        switch (step) {
-            case 'STEP_0': return '/onboarding/step-0';
-            case 'STEP_1': return '/onboarding/step-1';
-            case 'STEP_2': return '/onboarding/step-2';
-            case 'STEP_3': return '/onboarding/step-3';
-            case 'STEP_4': return '/onboarding/step-4';
-            case 'STEP_5': return '/onboarding/step-5';
-            default: return '/dashboard';
-        }
-    }
-
-    function pathToStep(path: string): number {
-        if (path.includes('step-0')) return 0;
-        if (path.includes('step-1')) return 1;
-        if (path.includes('step-2')) return 2;
-        if (path.includes('step-3')) return 3;
-        if (path.includes('step-4')) return 4;
-        if (path.includes('step-5')) return 5;
-        return -1;
-    }
-
     if (loading) {
         return <LoadingView message={statusMessage} />;
     }
@@ -157,7 +135,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
         return (
             <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
                 <div className="text-center">
-                    <h2 className="text-xl font-bold text-gray-900 mb-2">Error de conexión</h2>
+                    <h2 className="text-xl font-bold text-gray-900 mb-2">Error de conexion</h2>
                     <p className="text-gray-600 mb-4">No pudimos verificar tu estado. Intenta recargar.</p>
                     <button
                         onClick={() => {
@@ -168,9 +146,6 @@ export default function AuthGuard({ children }: AuthGuardProps) {
                     >
                         Reintentar
                     </button>
-                    <pre className="mt-4 text-xs text-left bg-gray-100 p-2 rounded text-red-500 overflow-auto max-w-lg">
-                        {JSON.stringify(error, null, 2)}
-                    </pre>
                 </div>
             </div>
         );

--- a/didacta-web/src/components/dashboard/SetupGuide.tsx
+++ b/didacta-web/src/components/dashboard/SetupGuide.tsx
@@ -1,0 +1,95 @@
+export interface SetupProgress {
+    hasGroup: boolean;
+    hasStudents: boolean;
+    hasAttendance: boolean;
+    hasCollaborators: boolean;
+    suggestedNextAction: string;
+    groupCount: number;
+    studentCount: number;
+    collaboratorCount: number;
+}
+
+interface SetupGuideProps {
+    setupProgress: SetupProgress;
+}
+
+interface ActionConfig {
+    title: string;
+    description: string;
+    buttonLabel: string;
+    icon: React.ReactNode;
+}
+
+const actionMap: Record<string, ActionConfig> = {
+    CREATE_GROUP: {
+        title: 'Crea tu primer grupo para comenzar',
+        description: 'Un grupo representa un salon o clase. Define grado, turno y nombre para empezar a registrar alumnos y sesiones.',
+        buttonLabel: 'Crear grupo',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+        ),
+    },
+    ADD_STUDENTS: {
+        title: 'Agrega alumnos a tus grupos',
+        description: 'Registra a los alumnos de cada grupo para poder llevar asistencia y crear sesiones.',
+        buttonLabel: 'Agregar alumnos',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+            </svg>
+        ),
+    },
+    TAKE_ATTENDANCE: {
+        title: 'Crea tu primera sesion',
+        description: 'Registra una clase o jornada y pasa lista de asistencia para comenzar a generar evidencia.',
+        buttonLabel: 'Nueva sesion',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" />
+            </svg>
+        ),
+    },
+    INVITE_TEAM: {
+        title: 'Invita a tu equipo',
+        description: 'Agrega docentes y coordinadores para que colaboren contigo en la gestion de tu escuela.',
+        buttonLabel: 'Invitar',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" />
+            </svg>
+        ),
+    },
+};
+
+export default function SetupGuide({ setupProgress }: SetupGuideProps) {
+    const action = actionMap[setupProgress.suggestedNextAction];
+
+    if (!action || setupProgress.suggestedNextAction === 'ALL_DONE') {
+        return null;
+    }
+
+    return (
+        <div className="bg-white rounded-xl shadow-sm p-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center flex-shrink-0">
+                    {action.icon}
+                </div>
+                <div className="flex-1">
+                    <h3 className="font-bold text-gray-900">{action.title}</h3>
+                    <p className="text-sm text-gray-500 mt-1">{action.description}</p>
+                </div>
+                <button
+                    onClick={() => {
+                        // Placeholder - se conectara despues
+                    }}
+                    className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition flex-shrink-0"
+                >
+                    {action.buttonLabel}
+                </button>
+            </div>
+        </div>
+    );
+}
+

--- a/didacta-web/src/components/dashboard/WelcomePopup.tsx
+++ b/didacta-web/src/components/dashboard/WelcomePopup.tsx
@@ -1,0 +1,99 @@
+interface WelcomePopupProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const features = [
+    {
+        title: 'Crear grupos',
+        description: 'Organiza tus salones por grado y turno.',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+        ),
+    },
+    {
+        title: 'Agregar alumnos',
+        description: 'Registra a tus alumnos en cada grupo.',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+            </svg>
+        ),
+    },
+    {
+        title: 'Crear sesiones',
+        description: 'Registra clases, jornadas y actividades.',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
+        ),
+    },
+    {
+        title: 'Pasar asistencia',
+        description: 'Lleva el control diario de asistencia.',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" />
+            </svg>
+        ),
+    },
+    {
+        title: 'Invitar equipo',
+        description: 'Agrega docentes y coordinadores.',
+        icon: (
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" />
+            </svg>
+        ),
+    },
+];
+
+export default function WelcomePopup({ isOpen, onClose }: WelcomePopupProps) {
+    if (!isOpen) return null;
+
+    const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget) {
+            onClose();
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={handleOverlayClick}
+        >
+            <div className="bg-white rounded-xl shadow-xl w-full max-w-[480px] p-8">
+                <h2 className="text-2xl font-bold text-gray-900 mb-1 text-center">
+                    Tu espacio esta listo
+                </h2>
+                <p className="text-gray-500 text-center mb-6">
+                    Esto es lo que puedes hacer desde aqui
+                </p>
+
+                <div className="space-y-4 mb-8">
+                    {features.map((feature) => (
+                        <div key={feature.title} className="flex items-start gap-3">
+                            <div className="w-10 h-10 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center flex-shrink-0">
+                                {feature.icon}
+                            </div>
+                            <div>
+                                <p className="text-sm font-semibold text-gray-900">{feature.title}</p>
+                                <p className="text-sm text-gray-500">{feature.description}</p>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <button
+                    onClick={onClose}
+                    className="w-full bg-blue-600 text-white px-4 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+                >
+                    Entendido, comenzar
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/didacta-web/src/views/DashboardView.tsx
+++ b/didacta-web/src/views/DashboardView.tsx
@@ -1,14 +1,62 @@
-export default function DashboardView() {
-    return (
-        <div className="flex h-full items-center justify-center p-8 bg-gray-50">
-            <div className="text-center max-w-lg">
-                <div className="w-48 mx-auto mb-6">
-                    <img src="/logo.png" alt="Didacta Logo" className="w-full h-auto object-contain" />
-                </div>
-                <h1 className="text-3xl font-black text-gray-900 mb-2">¡Bienvenido a Didacta!</h1>
-                <p className="text-gray-500 mb-8">Tu espacio educativo está listo. Aún no tienes grupos ni sesiones activas asignadas.</p>
+import { useState, useEffect } from 'react';
+import api from '../api/didactaApi';
+import WelcomePopup from '../components/dashboard/WelcomePopup';
+import SetupGuide from '../components/dashboard/SetupGuide';
+import type { SetupProgress } from '../components/dashboard/SetupGuide';
 
-                <div className="grid grid-cols-2 gap-4 mb-8 w-full">
+interface MeResponse {
+    setupProgress?: SetupProgress;
+}
+
+export default function DashboardView() {
+    const [showWelcome, setShowWelcome] = useState(false);
+    const [setupProgress, setSetupProgress] = useState<SetupProgress | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const alreadyShown = localStorage.getItem('didacta_welcome_popup_shown');
+        if (!alreadyShown) {
+            setShowWelcome(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        api.get<MeResponse>('/api/me')
+            .then(res => {
+                if (res.data.setupProgress) {
+                    setSetupProgress(res.data.setupProgress);
+                }
+            })
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, []);
+
+    const handleCloseWelcome = () => {
+        setShowWelcome(false);
+        localStorage.setItem('didacta_welcome_popup_shown', 'true');
+    };
+
+    const groupCount = setupProgress?.groupCount ?? 0;
+    const studentCount = setupProgress?.studentCount ?? 0;
+    const collaboratorCount = setupProgress?.collaboratorCount ?? 0;
+
+    if (loading) {
+        return (
+            <div className="flex h-full items-center justify-center p-8 bg-gray-50">
+                <p className="text-gray-500">Cargando...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="h-full overflow-y-auto bg-gray-50">
+            <WelcomePopup isOpen={showWelcome} onClose={handleCloseWelcome} />
+
+            <div className="max-w-4xl mx-auto p-6 sm:p-8">
+                <h1 className="text-2xl font-bold text-gray-900 mb-6">Dashboard</h1>
+
+                {/* Stat Cards */}
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                     <StatCard
                         label="Planteles"
                         value="1"
@@ -16,38 +64,31 @@ export default function DashboardView() {
                     />
                     <StatCard
                         label="Grupos"
-                        value="0"
+                        value={String(groupCount)}
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>}
                     />
                     <StatCard
                         label="Alumnos"
-                        value="0"
+                        value={String(studentCount)}
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>}
                     />
                     <StatCard
-                        label="Docentes"
-                        value="1"
+                        label="Colaboradores"
+                        value={String(collaboratorCount)}
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>}
                     />
                 </div>
 
-                <div className="p-6 bg-white rounded-2xl border border-gray-100 shadow-sm text-left">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <h3 className="font-bold text-gray-900">Configuración Pendiente</h3>
-                            <p className="text-xs text-gray-500 mt-1">Crea tus primeros grupos para comenzar.</p>
-                        </div>
-                        <button className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors">
-                            Crear Grupo
-                        </button>
-                    </div>
-                </div>
+                {/* Setup Guide */}
+                {setupProgress && setupProgress.suggestedNextAction !== 'ALL_DONE' && (
+                    <SetupGuide setupProgress={setupProgress} />
+                )}
             </div>
         </div>
     );
 }
 
-function StatCard({ label, value, icon }: { label: string, value: string, icon: React.ReactNode }) {
+function StatCard({ label, value, icon }: { label: string; value: string; icon: React.ReactNode }) {
     return (
         <div className="bg-white p-4 rounded-xl border border-gray-100 shadow-sm flex items-center gap-4 transition-transform hover:scale-105">
             <div className="w-10 h-10 rounded-full bg-blue-50 text-blue-600 flex items-center justify-center">

--- a/didacta-web/src/views/onboarding/OnboardingLayout.tsx
+++ b/didacta-web/src/views/onboarding/OnboardingLayout.tsx
@@ -11,7 +11,7 @@ interface OnboardingLayoutProps {
 }
 
 export default function OnboardingLayout({ step, title, subtitle, children, maxWidth = "max-w-2xl" }: OnboardingLayoutProps) {
-    const totalSteps = 5;
+    const totalSteps = 2;
 
     return (
         <div className="min-h-screen bg-white">

--- a/didacta-web/src/views/onboarding/Step0Welcome.tsx
+++ b/didacta-web/src/views/onboarding/Step0Welcome.tsx
@@ -3,9 +3,8 @@ import UserProfileMenu from '../../components/UserProfileMenu';
 
 const steps = [
     { num: 1, label: 'Registrar tu escuela' },
-    { num: 2, label: 'Crear tu primer grupo' },
-    { num: 3, label: 'Agregar a tus alumnos' },
-    { num: 4, label: 'Pasar tu primera asistencia' },
+    { num: 2, label: 'Invitar a tu equipo (opcional)' },
+    { num: 3, label: 'Explorar tu dashboard' },
 ];
 
 export default function Step0Welcome() {
@@ -32,7 +31,7 @@ export default function Step0Welcome() {
                     </p>
 
                     <div className="text-left max-w-sm mx-auto mb-10">
-                        <p className="text-sm font-medium text-gray-700 mb-4">Qué vamos a hacer:</p>
+                        <p className="text-sm font-medium text-gray-700 mb-4">Que vamos a hacer:</p>
                         <div className="space-y-3">
                             {steps.map((s) => (
                                 <div key={s.num} className="flex items-center gap-3 text-gray-600">

--- a/didacta-web/src/views/onboarding/Step1Institution.tsx
+++ b/didacta-web/src/views/onboarding/Step1Institution.tsx
@@ -4,6 +4,30 @@ import api from '../../api/didactaApi';
 import OnboardingLayout from './OnboardingLayout';
 import InlineError from '../../components/InlineError';
 
+interface SectionEntry {
+    level: string;
+    accreditationType: string;
+    accreditationKey: string;
+}
+
+const LEVEL_OPTIONS = [
+    { value: 'MATERNAL', label: 'Maternal / Guarderia' },
+    { value: 'INICIAL', label: 'Inicial' },
+    { value: 'PREESCOLAR', label: 'Preescolar' },
+    { value: 'PRIMARIA', label: 'Primaria' },
+    { value: 'SECUNDARIA', label: 'Secundaria' },
+    { value: 'MEDIA_SUPERIOR', label: 'Media Superior' },
+    { value: 'EMPRESARIAL', label: 'Empresarial / Capacitacion' },
+];
+
+const ACCREDITATION_OPTIONS = [
+    { value: 'NONE', label: 'Ninguna' },
+    { value: 'SEP_RVOE', label: 'SEP (RVOE)' },
+    { value: 'UNAM_DGIRE', label: 'UNAM (DGIRE)' },
+    { value: 'IPN', label: 'IPN' },
+    { value: 'OTHER', label: 'Otra' },
+];
+
 export default function Step1Institution() {
     const navigate = useNavigate();
     const [formData, setFormData] = useState({
@@ -13,7 +37,8 @@ export default function Step1Institution() {
         timezone: 'America/Mexico_City',
         role: '',
         hasMultipleCampuses: false,
-        campusName: ''
+        campusName: '',
+        sections: [] as SectionEntry[],
     });
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -22,6 +47,7 @@ export default function Step1Institution() {
         api.get('/api/onboarding/institution-details')
             .then(res => {
                 if (res.data) {
+                    const sections: SectionEntry[] = res.data.sections || [];
                     setFormData(prev => ({
                         ...prev,
                         name: res.data.name || '',
@@ -30,19 +56,63 @@ export default function Step1Institution() {
                         timezone: res.data.timezone || 'America/Mexico_City',
                         role: res.data.role || '',
                         hasMultipleCampuses: res.data.hasMultipleCampuses || false,
-                        campusName: res.data.campusName || ''
+                        campusName: res.data.campusName || '',
+                        sections: sections.length > 0 ? sections : [],
                     }));
                 }
             })
             .catch(() => {});
     }, []);
 
+    const toggleLevel = (level: string) => {
+        setFormData(prev => {
+            const existing = prev.sections.find(s => s.level === level);
+            let newSections: SectionEntry[];
+            if (existing) {
+                newSections = prev.sections.filter(s => s.level !== level);
+            } else {
+                newSections = [...prev.sections, { level, accreditationType: 'NONE', accreditationKey: '' }];
+            }
+            // Update mainLevel to be the first selected or empty
+            const mainLevel = newSections.length > 0 ? newSections[0].level : '';
+            return { ...prev, sections: newSections, mainLevel };
+        });
+    };
+
+    const updateSectionAccreditation = (level: string, accreditationType: string) => {
+        setFormData(prev => ({
+            ...prev,
+            sections: prev.sections.map(s =>
+                s.level === level ? { ...s, accreditationType, accreditationKey: accreditationType === 'NONE' ? '' : s.accreditationKey } : s
+            ),
+        }));
+    };
+
+    const updateSectionKey = (level: string, accreditationKey: string) => {
+        setFormData(prev => ({
+            ...prev,
+            sections: prev.sections.map(s =>
+                s.level === level ? { ...s, accreditationKey } : s
+            ),
+        }));
+    };
+
+    const isLevelSelected = (level: string) => formData.sections.some(s => s.level === level);
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        if (formData.sections.length === 0) {
+            setError('Selecciona al menos un nivel educativo.');
+            return;
+        }
         setLoading(true);
         setError(null);
         try {
-            const response = await api.post('/api/onboarding/institution', formData);
+            const payload = {
+                ...formData,
+                mainLevel: formData.sections[0].level,
+            };
+            const response = await api.post('/api/onboarding/institution', payload);
             if (response.data && response.data.institutionId) {
                 localStorage.setItem('didacta_institution_id', response.data.institutionId);
             }
@@ -58,8 +128,8 @@ export default function Step1Institution() {
     return (
         <OnboardingLayout
             step={1}
-            title="Configura tu institución"
-            subtitle="Ingresa los datos principales de tu centro educativo. Podrás gestionar sedes y permisos más adelante."
+            title="Configura tu institucion"
+            subtitle="Ingresa los datos principales de tu centro educativo. Podras gestionar sedes y permisos mas adelante."
         >
             {loading && (
                 <div className="absolute inset-0 bg-white/80 backdrop-blur-sm flex items-center justify-center z-10 rounded-xl">
@@ -73,7 +143,7 @@ export default function Step1Institution() {
                 <InlineError message={error} />
 
                 <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Nombre de la institución *</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Nombre de la institucion *</label>
                     <input
                         type="text"
                         required
@@ -84,42 +154,87 @@ export default function Step1Institution() {
                     />
                 </div>
 
+                {/* Multi-level selection */}
                 <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Nivel educativo principal</label>
-                    <select
-                        required
-                        className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 outline-none bg-white"
-                        value={formData.mainLevel}
-                        onChange={(e) => setFormData({ ...formData, mainLevel: e.target.value })}
-                    >
-                        <option value="">Selecciona un nivel</option>
-                        <option value="MATERNAL">Maternal</option>
-                        <option value="INICIAL">Inicial</option>
-                        <option value="PREESCOLAR">Preescolar</option>
-                        <option value="PRIMARIA">Primaria</option>
-                        <option value="SECUNDARIA">Secundaria</option>
-                        <option value="MEDIA_SUPERIOR">Media Superior</option>
-                        <option value="MIXTO">Mixto</option>
-                    </select>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Niveles educativos *</label>
+                    <p className="text-xs text-gray-500 mb-3">Selecciona todos los niveles que ofrece tu institucion.</p>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                        {LEVEL_OPTIONS.map((opt) => (
+                            <button
+                                type="button"
+                                key={opt.value}
+                                onClick={() => toggleLevel(opt.value)}
+                                className={`p-3 border rounded-lg text-sm font-medium transition ${
+                                    isLevelSelected(opt.value)
+                                        ? 'border-blue-600 bg-blue-50 text-blue-700 ring-1 ring-blue-600'
+                                        : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50 text-gray-700'
+                                }`}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
                 </div>
+
+                {/* Accreditation per selected level */}
+                {formData.sections.length > 0 && (
+                    <div className="space-y-4">
+                        <label className="block text-sm font-medium text-gray-700">Incorporacion por nivel</label>
+                        {formData.sections.map((section) => {
+                            const levelLabel = LEVEL_OPTIONS.find(l => l.value === section.level)?.label || section.level;
+                            return (
+                                <div key={section.level} className="bg-gray-50 p-4 rounded-xl border border-gray-200">
+                                    <div className="flex items-center gap-2 mb-2">
+                                        <span className="text-sm font-medium text-gray-900">{levelLabel}</span>
+                                    </div>
+                                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2">
+                                        {ACCREDITATION_OPTIONS.map((acc) => (
+                                            <button
+                                                type="button"
+                                                key={acc.value}
+                                                onClick={() => updateSectionAccreditation(section.level, acc.value)}
+                                                className={`px-3 py-1.5 border rounded-lg text-xs font-medium transition ${
+                                                    section.accreditationType === acc.value
+                                                        ? 'border-blue-600 bg-blue-50 text-blue-700'
+                                                        : 'border-gray-200 hover:border-gray-300 text-gray-600'
+                                                }`}
+                                            >
+                                                {acc.label}
+                                            </button>
+                                        ))}
+                                    </div>
+                                    {section.accreditationType !== 'NONE' && (
+                                        <input
+                                            type="text"
+                                            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 outline-none mt-2"
+                                            placeholder={section.accreditationType === 'SEP_RVOE' ? 'Clave RVOE (opcional)' : 'Clave de incorporacion (opcional)'}
+                                            value={section.accreditationKey}
+                                            onChange={(e) => updateSectionKey(section.level, e.target.value)}
+                                        />
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
 
                 <div className="grid grid-cols-2 gap-4">
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">País</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Pais</label>
                         <select disabled className="w-full border border-gray-300 rounded-lg px-4 py-2 bg-gray-50 text-gray-500">
-                            <option>México</option>
+                            <option>Mexico</option>
                         </select>
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">Zona horaria</label>
                         <select disabled className="w-full border border-gray-300 rounded-lg px-4 py-2 bg-gray-50 text-gray-500">
-                            <option>GMT-6 (Ciudad de México)</option>
+                            <option>GMT-6 (Ciudad de Mexico)</option>
                         </select>
                     </div>
                 </div>
 
                 <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-3">¿Cuál es tu rol en la institución?</label>
+                    <label className="block text-sm font-medium text-gray-700 mb-3">Tu rol en la institucion *</label>
                     <div className="grid grid-cols-3 gap-4">
                         {['DIRECTOR', 'OWNER', 'COORDINATOR'].map((role) => (
                             <button
@@ -132,7 +247,7 @@ export default function Step1Institution() {
                                     }`}
                             >
                                 <span className="font-medium text-sm">
-                                    {role === 'OWNER' ? 'Dueño' : role === 'DIRECTOR' ? 'Director' : 'Coordinador'}
+                                    {role === 'OWNER' ? 'Dueno' : role === 'DIRECTOR' ? 'Director' : 'Coordinador'}
                                 </span>
                             </button>
                         ))}
@@ -142,8 +257,8 @@ export default function Step1Institution() {
                 <div className="bg-gray-50 p-4 rounded-xl border border-gray-200">
                     <div className="flex items-center justify-between">
                         <div>
-                            <h4 className="text-sm font-medium text-gray-900">¿Cuentas con múltiples planteles?</h4>
-                            <p className="text-xs text-gray-500">Si activas esto, podrás registrar tu sede principal ahora.</p>
+                            <h4 className="text-sm font-medium text-gray-900">Multiples planteles?</h4>
+                            <p className="text-xs text-gray-500">Si activas esto, podras registrar tu sede principal ahora.</p>
                         </div>
                         <label className="relative inline-flex items-center cursor-pointer">
                             <input
@@ -173,10 +288,10 @@ export default function Step1Institution() {
                 <div className="flex justify-end pt-4">
                     <button
                         type="submit"
-                        disabled={loading || !formData.role || (formData.hasMultipleCampuses && !formData.campusName)}
+                        disabled={loading || !formData.role || formData.sections.length === 0 || (formData.hasMultipleCampuses && !formData.campusName)}
                         className="bg-blue-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-all active:scale-95"
                     >
-                        {loading ? 'Guardando...' : 'Continuar →'}
+                        {loading ? 'Guardando...' : 'Continuar'}
                     </button>
                 </div>
             </form>

--- a/didacta-web/src/views/onboarding/Step2Group.tsx
+++ b/didacta-web/src/views/onboarding/Step2Group.tsx
@@ -9,15 +9,33 @@ interface GradeOption {
     label: string;
 }
 
+interface SectionOption {
+    id: string;
+    level: string;
+    accreditationType: string;
+}
+
+const LEVEL_LABELS: Record<string, string> = {
+    MATERNAL: 'Maternal',
+    INICIAL: 'Inicial',
+    PREESCOLAR: 'Preescolar',
+    PRIMARIA: 'Primaria',
+    SECUNDARIA: 'Secundaria',
+    MEDIA_SUPERIOR: 'Media Superior',
+    EMPRESARIAL: 'Empresarial',
+};
+
 export default function Step2Group() {
     const navigate = useNavigate();
     const [formData, setFormData] = useState({
         name: '',
         gradeLevel: '',
         shift: 'MATUTINO',
-        campusId: ''
+        campusId: '',
+        sectionId: '',
     });
-    const [campuses, setCampuses] = useState<any[]>([]);
+    const [campuses, setCampuses] = useState<{ id: string; name: string }[]>([]);
+    const [sections, setSections] = useState<SectionOption[]>([]);
     const [grades, setGrades] = useState<GradeOption[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -33,16 +51,14 @@ export default function Step2Group() {
             })
             .catch(console.error);
 
-        // Fetch institution level to load grades
-        api.get('/api/onboarding/institution-level')
+        // Fetch Sections
+        api.get('/api/onboarding/sections')
             .then(res => {
-                if (res.data?.level) {
-                    return api.get(`/api/catalogs/grades?level=${res.data.level}`);
-                }
-            })
-            .then(res => {
-                if (res?.data) {
-                    setGrades(res.data);
+                setSections(res.data);
+                if (res.data.length === 1) {
+                    setFormData(prev => ({ ...prev, sectionId: res.data[0].id }));
+                    // Load grades for the single section's level
+                    loadGradesForLevel(res.data[0].level);
                 }
             })
             .catch(console.error);
@@ -57,12 +73,33 @@ export default function Step2Group() {
                         name: existing.name,
                         gradeLevel: existing.gradeLevel || '',
                         shift: existing.shift || 'MATUTINO',
-                        campusId: existing.campus ? existing.campus.id : prev.campusId
+                        campusId: existing.campus ? existing.campus.id : prev.campusId,
+                        sectionId: existing.sectionId || prev.sectionId,
                     }));
                 }
             })
             .catch(console.error);
     }, []);
+
+    const loadGradesForLevel = (level: string) => {
+        api.get(`/api/catalogs/grades?level=${level}`)
+            .then(res => {
+                if (res?.data) {
+                    setGrades(res.data);
+                }
+            })
+            .catch(console.error);
+    };
+
+    const handleSectionChange = (sectionId: string) => {
+        setFormData(prev => ({ ...prev, sectionId, gradeLevel: '' }));
+        const section = sections.find(s => s.id === sectionId);
+        if (section) {
+            loadGradesForLevel(section.level);
+        } else {
+            setGrades([]);
+        }
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -83,7 +120,7 @@ export default function Step2Group() {
         <OnboardingLayout
             step={2}
             title="Configura tu primer grupo"
-            subtitle="Dale identidad a tu clase. Podrás gestionar alumnos y asignaturas una vez creado el espacio."
+            subtitle="Dale identidad a tu clase. Podras gestionar alumnos y asignaturas una vez creado el espacio."
         >
             <form onSubmit={handleSubmit} className="space-y-6 max-w-xl mx-auto">
                 <InlineError message={error} />
@@ -99,8 +136,28 @@ export default function Step2Group() {
                             onChange={(e) => setFormData({ ...formData, campusId: e.target.value })}
                         >
                             <option value="">Selecciona un plantel</option>
-                            {campuses.map((c: any) => (
+                            {campuses.map((c) => (
                                 <option key={c.id} value={c.id}>{c.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+
+                {/* Section Selection - Show only if > 1 */}
+                {sections.length > 1 && (
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Nivel educativo</label>
+                        <select
+                            required
+                            className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 outline-none bg-white"
+                            value={formData.sectionId}
+                            onChange={(e) => handleSectionChange(e.target.value)}
+                        >
+                            <option value="">Selecciona un nivel</option>
+                            {sections.map((s) => (
+                                <option key={s.id} value={s.id}>
+                                    {LEVEL_LABELS[s.level] || s.level}
+                                </option>
                             ))}
                         </select>
                     </div>
@@ -169,14 +226,14 @@ export default function Step2Group() {
                         onClick={() => navigate('/onboarding/step-1')}
                         className="text-gray-500 font-medium hover:text-gray-700 px-6 py-3 rounded-lg hover:bg-gray-100 transition"
                     >
-                        ← Volver
+                        Volver
                     </button>
                     <button
                         type="submit"
-                        disabled={loading || (campuses.length > 1 && !formData.campusId)}
+                        disabled={loading || (campuses.length > 1 && !formData.campusId) || (sections.length > 1 && !formData.sectionId)}
                         className="bg-blue-600 text-white px-8 py-3 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 shadow-sm shadow-blue-200 flex-1"
                     >
-                        {loading ? 'Guardando...' : 'Continuar →'}
+                        {loading ? 'Guardando...' : 'Continuar'}
                     </button>
                 </div>
             </form>

--- a/didacta-web/src/views/onboarding/Step2InviteUser.tsx
+++ b/didacta-web/src/views/onboarding/Step2InviteUser.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api/didactaApi';
+import OnboardingLayout from './OnboardingLayout';
+import InlineError from '../../components/InlineError';
+
+interface RoleCatalogItem {
+    value: string;
+    label: string;
+}
+
+export default function Step2InviteUser() {
+    const navigate = useNavigate();
+    const [roles, setRoles] = useState<RoleCatalogItem[]>([]);
+    const [fullName, setFullName] = useState('');
+    const [email, setEmail] = useState('');
+    const [role, setRole] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [emailError, setEmailError] = useState<string | null>(null);
+
+    useEffect(() => {
+        api.get('/api/catalogs/roles')
+            .then(res => setRoles(res.data))
+            .catch(console.error);
+    }, []);
+
+    const validateEmail = (value: string): boolean => {
+        if (!value) return true;
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailRegex.test(value);
+    };
+
+    const handleEmailChange = (value: string) => {
+        setEmail(value);
+        if (value && !validateEmail(value)) {
+            setEmailError('Ingresa un correo valido');
+        } else {
+            setEmailError(null);
+        }
+    };
+
+    const canSubmit = email.trim() !== '' && role !== '' && !emailError;
+
+    const handleInviteAndContinue = async () => {
+        if (!canSubmit) return;
+
+        setLoading(true);
+        setError(null);
+        try {
+            await api.post('/api/onboarding/collaborators', {
+                collaborators: [
+                    {
+                        email: email.trim(),
+                        fullName: fullName.trim(),
+                        role,
+                    },
+                ],
+            });
+            navigate('/dashboard');
+        } catch (err) {
+            console.error(err);
+            setError('Error al enviar la invitacion. Intenta de nuevo.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSkip = () => {
+        navigate('/dashboard');
+    };
+
+    return (
+        <OnboardingLayout
+            step={2}
+            title="Invita a tu equipo"
+            subtitle="Agrega a un colaborador para que te ayude a configurar tu escuela."
+        >
+            <InlineError message={error} />
+
+            {/* Info banner */}
+            <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 mb-6 text-sm text-blue-800">
+                Este usuario recibira un correo para crear su cuenta y podra comenzar a configurar grupos, alumnos y sesiones.
+            </div>
+
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Nombre completo
+                    </label>
+                    <input
+                        type="text"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+                        placeholder="Ej. Ana Lopez"
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Correo electronico <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                        type="email"
+                        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${
+                            emailError ? 'border-red-300' : 'border-gray-300'
+                        }`}
+                        placeholder="nombre@institucion.edu"
+                        value={email}
+                        onChange={(e) => handleEmailChange(e.target.value)}
+                    />
+                    {emailError && (
+                        <p className="text-red-500 text-xs mt-1">{emailError}</p>
+                    )}
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Rol <span className="text-red-500">*</span>
+                    </label>
+                    <select
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none"
+                        value={role}
+                        onChange={(e) => setRole(e.target.value)}
+                    >
+                        <option value="">Seleccionar rol</option>
+                        {roles.length > 0 ? (
+                            roles.map((r) => (
+                                <option key={r.value} value={r.value}>{r.label}</option>
+                            ))
+                        ) : (
+                            <>
+                                <option value="COORDINATOR">Coordinador</option>
+                                <option value="TEACHER">Docente</option>
+                                <option value="ADMIN">Administrativo</option>
+                            </>
+                        )}
+                    </select>
+                </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-3 mt-8">
+                <button
+                    onClick={() => navigate('/onboarding/step-1')}
+                    className="text-gray-500 font-medium hover:text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-100 transition order-3 sm:order-1"
+                >
+                    Volver
+                </button>
+
+                <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto order-1 sm:order-2">
+                    <button
+                        onClick={handleSkip}
+                        className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 text-sm font-medium transition"
+                    >
+                        Omitir por ahora
+                    </button>
+                    <button
+                        onClick={handleInviteAndContinue}
+                        disabled={!canSubmit || loading}
+                        className="bg-blue-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition text-sm"
+                    >
+                        {loading ? 'Enviando...' : 'Invitar y continuar'}
+                    </button>
+                </div>
+            </div>
+        </OnboardingLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- Introduces AcademicSection entity for multi-level support per institution
- Adds complete calendar system with global templates copied as editable institution calendars
- Modifies onboarding Step 1 for multi-level selection with per-level accreditation
- Modifies onboarding Step 2 to include section selector for group creation

## Backend
- Migration V6: 6 new tables with seed data for 4 calendar templates (59 events)
- 5 new domain entities following hexagonal architecture
- Full ports and adapters: 4 output ports, 3 input use cases, 5 JPA repos, 4 persistence adapters
- New endpoints: /api/sections, /api/calendars, /api/catalogs/calendar-templates
- Modified CreateInstitutionService and CreateGroupService

## Frontend
- Step1Institution: Multi-level checkboxes with per-level accreditation selector
- Step2Group: Section/level selector dropdown when multiple sections exist

## Test plan
- [ ] Create institution with single/multiple levels
- [ ] Verify calendar auto-assignment based on level and accreditation
- [ ] Create group with section selector
- [ ] GET/POST calendar endpoints
- [ ] Existing data migration verified