### PR TITLE
Add calendar system with academic sections and template matching

### DIFF
--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/SetupInstitutionUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/SetupInstitutionUseCase.java
@@ -1,0 +1,7 @@
+package com.didacta.api.application.port.input;
+
+import com.didacta.api.application.dto.OnboardingCommand;
+
+public interface SetupInstitutionUseCase {
+    void setupSectionsAndCalendars(OnboardingCommand.CreateInstitution command);
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarTemplateRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/CalendarTemplateRepositoryPort.java
@@ -11,5 +11,6 @@ public interface CalendarTemplateRepositoryPort {
     List<CalendarTemplate> findAllActive();
     Optional<CalendarTemplate> findById(UUID id);
     List<CalendarTemplate> findByApplicableLevelAndAccreditation(String level, boolean requiresAccreditation);
+    List<CalendarTemplate> findByApplicableLevelAndAuthority(String level, String authority);
     List<CalendarTemplateEvent> findEventsByTemplateId(UUID templateId);
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/TenantProviderPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/TenantProviderPort.java
@@ -5,4 +5,5 @@ import java.util.UUID;
 public interface TenantProviderPort {
     String getTenantId();
     UUID getTenantUUID();
+    void setTenantId(String tenantId);
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateInstitutionService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/CreateInstitutionService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,10 +23,6 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
     private final MembershipRepositoryPort membershipRepository;
     private final CampusRepositoryPort campusRepository;
     private final SchoolYearRepositoryPort schoolYearRepository;
-    private final AcademicSectionRepositoryPort sectionRepository;
-    private final CalendarTemplateRepositoryPort templateRepository;
-    private final InstitutionCalendarRepositoryPort calendarRepository;
-    private final CalendarEventRepositoryPort calendarEventRepository;
 
     @Override
     @Transactional
@@ -70,10 +67,6 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
 
         institutionRepository.save(institution);
         membershipRepository.save(membership);
-
-        // Recreate academic sections
-        createOrUpdateSections(institution, command);
-
         return institution;
     }
 
@@ -99,125 +92,23 @@ public class CreateInstitutionService implements CreateInstitutionUseCase {
         membership.setStatus("ACTIVE");
         membershipRepository.save(membership);
 
-        // Auto-create school year
-        SchoolYear schoolYear = createCurrentSchoolYear(institution);
-
-        // Create academic sections and auto-assign calendars
-        createOrUpdateSections(institution, command);
+        // Create school year (not tenant-scoped)
+        createCurrentSchoolYear(institution);
 
         return institution;
     }
 
-    private void createOrUpdateSections(Institution institution, OnboardingCommand.CreateInstitution command) {
-        List<OnboardingCommand.SectionEntry> sections = command.getSections();
-
-        if (sections == null || sections.isEmpty()) {
-            // Backward compatibility: create a single section from mainLevel
-            createSectionIfNotExists(institution, command.getMainLevel(), "NONE", null, 0);
-        } else {
-            int order = 0;
-            for (OnboardingCommand.SectionEntry entry : sections) {
-                createSectionIfNotExists(institution, entry.getLevel(),
-                        entry.getAccreditationType(), entry.getAccreditationKey(), order++);
-            }
-        }
-
-        // Auto-assign calendars for each section
-        autoAssignCalendars(institution);
-    }
-
-    private void createSectionIfNotExists(Institution institution, String level,
-                                           String accreditationType, String accreditationKey, int order) {
-        Optional<AcademicSection> existing = sectionRepository.findByInstitutionIdAndLevel(institution.getId(), level);
-        if (existing.isPresent()) {
-            AcademicSection section = existing.get();
-            section.setAccreditationType(accreditationType);
-            section.setAccreditationKey(accreditationKey);
-            section.setDisplayOrder(order);
-            sectionRepository.save(section);
-        } else {
-            AcademicSection section = AcademicSection.builder()
-                    .institution(institution)
-                    .level(level)
-                    .accreditationType(accreditationType != null ? accreditationType : "NONE")
-                    .accreditationKey(accreditationKey)
-                    .displayOrder(order)
-                    .active(true)
-                    .build();
-            sectionRepository.save(section);
-        }
-    }
-
-    private void autoAssignCalendars(Institution institution) {
-        Optional<SchoolYear> schoolYearOpt = schoolYearRepository.findByInstitutionIdAndStatus(institution.getId(), "ACTIVE");
-        if (schoolYearOpt.isEmpty()) return;
-
-        SchoolYear schoolYear = schoolYearOpt.get();
-        List<AcademicSection> sections = sectionRepository.findByInstitutionId(institution.getId());
-
-        for (AcademicSection section : sections) {
-            // Skip if calendar already exists
-            Optional<InstitutionCalendar> existingCal = calendarRepository
-                    .findByInstitutionIdAndSectionIdAndSchoolYearId(institution.getId(), section.getId(), schoolYear.getId());
-            if (existingCal.isPresent()) continue;
-
-            // Find matching template
-            boolean hasAccreditation = !"NONE".equals(section.getAccreditationType());
-            List<CalendarTemplate> templates = templateRepository
-                    .findByApplicableLevelAndAccreditation(section.getLevel(), hasAccreditation);
-
-            if (templates.isEmpty() && hasAccreditation) {
-                // Fall back to non-accreditation templates
-                templates = templateRepository.findByApplicableLevelAndAccreditation(section.getLevel(), false);
-            }
-
-            if (templates.isEmpty()) continue;
-
-            CalendarTemplate template = templates.get(0);
-
-            // Create institution calendar
-            InstitutionCalendar calendar = InstitutionCalendar.builder()
-                    .institution(institution)
-                    .section(section)
-                    .schoolYear(schoolYear)
-                    .sourceTemplate(template)
-                    .name(template.getName())
-                    .status("ACTIVE")
-                    .build();
-            calendarRepository.save(calendar);
-
-            // Copy template events
-            List<CalendarTemplateEvent> templateEvents = templateRepository.findEventsByTemplateId(template.getId());
-            List<CalendarEvent> calendarEvents = templateEvents.stream()
-                    .map(te -> CalendarEvent.builder()
-                            .calendar(calendar)
-                            .sourceTemplateEvent(te)
-                            .name(te.getName())
-                            .eventType(te.getEventType())
-                            .startDate(te.getStartDate())
-                            .endDate(te.getEndDate())
-                            .affectsClasses(te.getAffectsClasses())
-                            .affectsStaff(te.getAffectsStaff())
-                            .isFromTemplate(true)
-                            .isDeleted(false)
-                            .build())
-                    .toList();
-            calendarEventRepository.saveAll(calendarEvents);
-        }
-    }
-
-    private SchoolYear createCurrentSchoolYear(Institution institution) {
-        java.time.LocalDate now = java.time.LocalDate.now();
+    private void createCurrentSchoolYear(Institution institution) {
+        LocalDate now = LocalDate.now();
         int startYear = now.getMonthValue() >= 8 ? now.getYear() : now.getYear() - 1;
         int endYear = startYear + 1;
 
         SchoolYear sy = new SchoolYear();
         sy.setInstitution(institution);
         sy.setName(startYear + "-" + endYear);
-        sy.setStartDate(java.time.LocalDate.of(startYear, 8, 1));
-        sy.setEndDate(java.time.LocalDate.of(endYear, 7, 31));
+        sy.setStartDate(LocalDate.of(startYear, 8, 1));
+        sy.setEndDate(LocalDate.of(endYear, 7, 31));
         sy.setStatus("ACTIVE");
         schoolYearRepository.save(sy);
-        return sy;
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/SetupInstitutionService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/SetupInstitutionService.java
@@ -1,0 +1,139 @@
+package com.didacta.api.application.usecase;
+
+import com.didacta.api.application.dto.OnboardingCommand;
+import com.didacta.api.application.port.input.SetupInstitutionUseCase;
+import com.didacta.api.application.port.output.*;
+import com.didacta.api.domain.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SetupInstitutionService implements SetupInstitutionUseCase {
+
+    private final TenantProviderPort tenantProvider;
+    private final InstitutionRepositoryPort institutionRepository;
+    private final SchoolYearRepositoryPort schoolYearRepository;
+    private final AcademicSectionRepositoryPort sectionRepository;
+    private final CalendarTemplateRepositoryPort templateRepository;
+    private final InstitutionCalendarRepositoryPort calendarRepository;
+    private final CalendarEventRepositoryPort calendarEventRepository;
+
+    @Override
+    @Transactional
+    public void setupSectionsAndCalendars(OnboardingCommand.CreateInstitution command) {
+        java.util.UUID institutionId = tenantProvider.getTenantUUID();
+        Institution institution = institutionRepository.findById(institutionId)
+                .orElseThrow(() -> new com.didacta.api.domain.exception.EntityNotFoundException("Institution", institutionId.toString()));
+
+        // Create academic sections
+        List<OnboardingCommand.SectionEntry> sections = command.getSections();
+        if (sections == null || sections.isEmpty()) {
+            createSectionIfNotExists(institution, command.getMainLevel(), "NONE", null, 0);
+        } else {
+            int order = 0;
+            for (OnboardingCommand.SectionEntry entry : sections) {
+                createSectionIfNotExists(institution, entry.getLevel(),
+                        entry.getAccreditationType(), entry.getAccreditationKey(), order++);
+            }
+        }
+
+        // Auto-assign calendars for each section
+        autoAssignCalendars(institution);
+    }
+
+    private void createSectionIfNotExists(Institution institution, String level,
+                                           String accreditationType, String accreditationKey, int order) {
+        Optional<AcademicSection> existing = sectionRepository.findByInstitutionIdAndLevel(institution.getId(), level);
+        if (existing.isPresent()) {
+            AcademicSection section = existing.get();
+            section.setAccreditationType(accreditationType);
+            section.setAccreditationKey(accreditationKey);
+            section.setDisplayOrder(order);
+            sectionRepository.save(section);
+        } else {
+            AcademicSection section = AcademicSection.builder()
+                    .institution(institution)
+                    .level(level)
+                    .accreditationType(accreditationType != null ? accreditationType : "NONE")
+                    .accreditationKey(accreditationKey)
+                    .displayOrder(order)
+                    .active(true)
+                    .build();
+            sectionRepository.save(section);
+        }
+    }
+
+    private void autoAssignCalendars(Institution institution) {
+        Optional<SchoolYear> schoolYearOpt = schoolYearRepository.findByInstitutionIdAndStatus(institution.getId(), "ACTIVE");
+        if (schoolYearOpt.isEmpty()) return;
+
+        SchoolYear schoolYear = schoolYearOpt.get();
+        List<AcademicSection> sections = sectionRepository.findByInstitutionId(institution.getId());
+
+        for (AcademicSection section : sections) {
+            Optional<InstitutionCalendar> existingCal = calendarRepository
+                    .findByInstitutionIdAndSectionIdAndSchoolYearId(institution.getId(), section.getId(), schoolYear.getId());
+            if (existingCal.isPresent()) continue;
+
+            boolean hasAccreditation = !"NONE".equals(section.getAccreditationType());
+            List<CalendarTemplate> templates;
+
+            // First try to match by specific authority (e.g., UNAM_DGIRE, SEP_RVOE, IPN)
+            if (hasAccreditation) {
+                templates = templateRepository.findByApplicableLevelAndAuthority(
+                        section.getLevel(), section.getAccreditationType());
+            } else {
+                templates = templateRepository.findByApplicableLevelAndAccreditation(
+                        section.getLevel(), false);
+            }
+
+            // Fallback: any accredited template for this level
+            if (templates.isEmpty() && hasAccreditation) {
+                templates = templateRepository.findByApplicableLevelAndAccreditation(
+                        section.getLevel(), true);
+            }
+
+            // Final fallback: non-accredited template for this level
+            if (templates.isEmpty()) {
+                templates = templateRepository.findByApplicableLevelAndAccreditation(
+                        section.getLevel(), false);
+            }
+
+            if (templates.isEmpty()) continue;
+
+            CalendarTemplate template = templates.get(0);
+
+            InstitutionCalendar calendar = InstitutionCalendar.builder()
+                    .institution(institution)
+                    .section(section)
+                    .schoolYear(schoolYear)
+                    .sourceTemplate(template)
+                    .name(template.getName())
+                    .status("ACTIVE")
+                    .build();
+            calendarRepository.save(calendar);
+
+            List<CalendarTemplateEvent> templateEvents = templateRepository.findEventsByTemplateId(template.getId());
+            List<CalendarEvent> calendarEvents = templateEvents.stream()
+                    .map(te -> CalendarEvent.builder()
+                            .calendar(calendar)
+                            .sourceTemplateEvent(te)
+                            .name(te.getName())
+                            .eventType(te.getEventType())
+                            .startDate(te.getStartDate())
+                            .endDate(te.getEndDate())
+                            .affectsClasses(te.getAffectsClasses())
+                            .affectsStaff(te.getAffectsStaff())
+                            .isFromTemplate(true)
+                            .isDeleted(false)
+                            .build())
+                    .toList();
+            calendarEventRepository.saveAll(calendarEvents);
+        }
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/OnboardingController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/OnboardingController.java
@@ -24,6 +24,7 @@ public class OnboardingController {
     private final ManageAttendanceUseCase manageAttendance;
     private final ManageCollaboratorsUseCase manageCollaborators;
     private final GetInstitutionInfoUseCase getInstitutionInfo;
+    private final SetupInstitutionUseCase setupInstitution;
 
     @GetMapping("/me")
     public ResponseEntity<OnboardingResult.MeResponse> getMe(@AuthenticationPrincipal Jwt jwt) {
@@ -94,5 +95,12 @@ public class OnboardingController {
     @GetMapping("/onboarding/sections")
     public List<OnboardingResult.AcademicSectionDto> getSections() {
         return getInstitutionInfo.getSections();
+    }
+
+    @PostMapping("/onboarding/setup")
+    public ResponseEntity<Void> setupInstitution(
+            @Valid @RequestBody OnboardingCommand.CreateInstitution command) {
+        setupInstitution.setupSectionsAndCalendars(command);
+        return ResponseEntity.ok().build();
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarTemplatePersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/CalendarTemplatePersistenceAdapter.java
@@ -35,6 +35,11 @@ public class CalendarTemplatePersistenceAdapter implements CalendarTemplateRepos
     }
 
     @Override
+    public List<CalendarTemplate> findByApplicableLevelAndAuthority(String level, String authority) {
+        return templateRepo.findByApplicableLevelAndAuthority(level, authority);
+    }
+
+    @Override
     public List<CalendarTemplateEvent> findEventsByTemplateId(UUID templateId) {
         return eventRepo.findByTemplateIdOrderBySortOrderAsc(templateId);
     }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaCalendarTemplateRepository.java
@@ -18,4 +18,7 @@ public interface JpaCalendarTemplateRepository extends JpaRepository<CalendarTem
 
     @Query("SELECT ct FROM CalendarTemplate ct WHERE ct.active = true AND ct.applicableLevels LIKE %:level% AND ct.requiresAccreditation = :requiresAccreditation")
     List<CalendarTemplate> findByApplicableLevelAndAccreditation(@Param("level") String level, @Param("requiresAccreditation") boolean requiresAccreditation);
+
+    @Query("SELECT ct FROM CalendarTemplate ct WHERE ct.active = true AND ct.applicableLevels LIKE %:level% AND ct.requiresAccreditation = true AND ct.accreditationAuthority = :authority")
+    List<CalendarTemplate> findByApplicableLevelAndAuthority(@Param("level") String level, @Param("authority") String authority);
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/tenant/TenantProviderAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/tenant/TenantProviderAdapter.java
@@ -23,4 +23,9 @@ public class TenantProviderAdapter implements TenantProviderPort {
         }
         return UUID.fromString(tenantId);
     }
+
+    @Override
+    public void setTenantId(String tenantId) {
+        TenantContext.setTenantId(tenantId);
+    }
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/security/TenantInterceptor.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/security/TenantInterceptor.java
@@ -27,6 +27,10 @@ public class TenantInterceptor extends OncePerRequestFilter {
     private final MembershipRepositoryPort membershipRepository;
     private final UserRepositoryPort userRepository;
 
+    private static final java.util.Set<String> TENANT_EXEMPT_PATHS = java.util.Set.of(
+            "/api/me", "/api/health", "/api/onboarding/institution"
+    );
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -34,7 +38,13 @@ public class TenantInterceptor extends OncePerRequestFilter {
         TenantContext.clear();
 
         try {
+            String requestPath = request.getRequestURI();
             String institutionIdHeader = request.getHeader(HEADER_INSTITUTION_ID);
+
+            // Skip tenant validation for exempt paths (global endpoints)
+            if (TENANT_EXEMPT_PATHS.contains(requestPath)) {
+                institutionIdHeader = null;
+            }
 
             // If no header, allow request (Global scope, e.g. /api/me)
             if (institutionIdHeader != null && !institutionIdHeader.isBlank()) {

--- a/didacta-api/src/main/resources/db/migration/V7__media_superior_and_inicial_templates.sql
+++ b/didacta-api/src/main/resources/db/migration/V7__media_superior_and_inicial_templates.sql
@@ -1,0 +1,119 @@
+-- =============================================
+-- V7: Calendar templates for MEDIA_SUPERIOR and INICIAL
+-- =============================================
+
+-- Template: UNAM DGIRE - Preparatoria incorporada a la UNAM 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000005', 'UNAM_DGIRE_2025_2026', 'Calendario UNAM (DGIRE) 2025-2026', 'Calendario para preparatorias incorporadas a la UNAM via DGIRE. Semestral con periodos de examenes ordinarios y extraordinarios.', '2025-2026', 'ANNUAL', 'UNAM', 'MEDIA_SUPERIOR', TRUE, 'UNAM_DGIRE', '2025-08-11', '2026-06-19', 180);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000005', 'Inicio de clases - Semestre 1', 'ADMIN', '2025-08-11', '2025-08-11', FALSE, FALSE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000005', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 2),
+('a1000000-0000-0000-0000-000000000005', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 3),
+('a1000000-0000-0000-0000-000000000005', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 4),
+('a1000000-0000-0000-0000-000000000005', 'Fin de clases - Semestre 1', 'ADMIN', '2025-12-05', '2025-12-05', FALSE, FALSE, TRUE, 5),
+('a1000000-0000-0000-0000-000000000005', 'Examenes ordinarios - Semestre 1', 'ADMIN', '2025-12-08', '2025-12-19', TRUE, FALSE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000005', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, TRUE, 7),
+('a1000000-0000-0000-0000-000000000005', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 8),
+('a1000000-0000-0000-0000-000000000005', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 9),
+('a1000000-0000-0000-0000-000000000005', 'Examenes extraordinarios - Semestre 1', 'ADMIN', '2026-01-12', '2026-01-23', TRUE, FALSE, FALSE, 10),
+('a1000000-0000-0000-0000-000000000005', 'Inicio de clases - Semestre 2', 'ADMIN', '2026-01-26', '2026-01-26', FALSE, FALSE, TRUE, 11),
+('a1000000-0000-0000-0000-000000000005', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000005', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 13),
+('a1000000-0000-0000-0000-000000000005', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, TRUE, 14),
+('a1000000-0000-0000-0000-000000000005', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000005', 'Batalla de Puebla', 'HOLIDAY', '2026-05-05', '2026-05-05', TRUE, TRUE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000005', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, TRUE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000005', 'Fin de clases - Semestre 2', 'ADMIN', '2026-05-29', '2026-05-29', FALSE, FALSE, TRUE, 18),
+('a1000000-0000-0000-0000-000000000005', 'Examenes ordinarios - Semestre 2', 'ADMIN', '2026-06-01', '2026-06-12', TRUE, FALSE, TRUE, 19),
+('a1000000-0000-0000-0000-000000000005', 'Examenes extraordinarios - Semestre 2', 'ADMIN', '2026-06-15', '2026-06-19', TRUE, FALSE, FALSE, 20);
+
+-- Template: SEP DGB - Preparatoria incorporada a SEP (Bachillerato General) 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000006', 'SEP_MEDIA_SUPERIOR_2025_2026', 'Calendario SEP Media Superior 2025-2026', 'Calendario para bachilleratos incorporados a la SEP (DGB, DGETI, DGETA). Semestral con jornadas COSDAC.', '2025-2026', 'ANNUAL', 'SEP', 'MEDIA_SUPERIOR', TRUE, 'SEP_RVOE', '2025-08-18', '2026-07-10', 185);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000006', 'Jornada academica de planeacion', 'CTE', '2025-08-18', '2025-08-22', TRUE, FALSE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000006', 'Inicio de clases - Semestre 1', 'ADMIN', '2025-08-25', '2025-08-25', FALSE, FALSE, TRUE, 2),
+('a1000000-0000-0000-0000-000000000006', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 3),
+('a1000000-0000-0000-0000-000000000006', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 4),
+('a1000000-0000-0000-0000-000000000006', 'Evaluaciones parciales - Semestre 1', 'ADMIN', '2025-11-24', '2025-11-28', FALSE, FALSE, TRUE, 5),
+('a1000000-0000-0000-0000-000000000006', 'Examenes semestrales - Semestre 1', 'ADMIN', '2025-12-08', '2025-12-12', TRUE, FALSE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000006', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, TRUE, 7),
+('a1000000-0000-0000-0000-000000000006', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 8),
+('a1000000-0000-0000-0000-000000000006', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 9),
+('a1000000-0000-0000-0000-000000000006', 'Inicio de clases - Semestre 2', 'ADMIN', '2026-01-12', '2026-01-12', FALSE, FALSE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000006', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 11),
+('a1000000-0000-0000-0000-000000000006', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000006', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, TRUE, 13),
+('a1000000-0000-0000-0000-000000000006', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 14),
+('a1000000-0000-0000-0000-000000000006', 'Batalla de Puebla', 'HOLIDAY', '2026-05-05', '2026-05-05', TRUE, TRUE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000006', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, TRUE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000006', 'Evaluaciones parciales - Semestre 2', 'ADMIN', '2026-05-25', '2026-05-29', FALSE, FALSE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000006', 'Examenes semestrales - Semestre 2', 'ADMIN', '2026-06-15', '2026-06-19', TRUE, FALSE, TRUE, 18),
+('a1000000-0000-0000-0000-000000000006', 'Fin de cursos', 'ADMIN', '2026-07-03', '2026-07-03', FALSE, FALSE, TRUE, 19),
+('a1000000-0000-0000-0000-000000000006', 'Vacaciones de verano', 'VACATION', '2026-07-11', '2026-08-17', TRUE, TRUE, FALSE, 20);
+
+-- Template: IPN - Preparatoria incorporada al IPN 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000007', 'IPN_MEDIA_SUPERIOR_2025_2026', 'Calendario IPN Media Superior 2025-2026', 'Calendario para escuelas incorporadas al IPN (CECyT y similares). Semestral.', '2025-2026', 'ANNUAL', 'IPN', 'MEDIA_SUPERIOR', TRUE, 'IPN', '2025-08-11', '2026-06-26', 180);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000007', 'Inicio de clases - Semestre 1', 'ADMIN', '2025-08-11', '2025-08-11', FALSE, FALSE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000007', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 2),
+('a1000000-0000-0000-0000-000000000007', 'Primer examen departamental', 'ADMIN', '2025-10-06', '2025-10-10', TRUE, FALSE, TRUE, 3),
+('a1000000-0000-0000-0000-000000000007', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 4),
+('a1000000-0000-0000-0000-000000000007', 'Segundo examen departamental', 'ADMIN', '2025-11-10', '2025-11-14', TRUE, FALSE, TRUE, 5),
+('a1000000-0000-0000-0000-000000000007', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000007', 'Tercer examen departamental', 'ADMIN', '2025-12-01', '2025-12-05', TRUE, FALSE, TRUE, 7),
+('a1000000-0000-0000-0000-000000000007', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, TRUE, 8),
+('a1000000-0000-0000-0000-000000000007', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 9),
+('a1000000-0000-0000-0000-000000000007', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000007', 'Periodo ETS - Semestre 1', 'ADMIN', '2026-01-12', '2026-01-23', TRUE, FALSE, FALSE, 11),
+('a1000000-0000-0000-0000-000000000007', 'Inicio de clases - Semestre 2', 'ADMIN', '2026-01-26', '2026-01-26', FALSE, FALSE, TRUE, 12),
+('a1000000-0000-0000-0000-000000000007', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 13),
+('a1000000-0000-0000-0000-000000000007', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 14),
+('a1000000-0000-0000-0000-000000000007', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, TRUE, 15),
+('a1000000-0000-0000-0000-000000000007', 'Cuarto examen departamental', 'ADMIN', '2026-04-13', '2026-04-17', TRUE, FALSE, TRUE, 16),
+('a1000000-0000-0000-0000-000000000007', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 17),
+('a1000000-0000-0000-0000-000000000007', 'Batalla de Puebla', 'HOLIDAY', '2026-05-05', '2026-05-05', TRUE, TRUE, TRUE, 18),
+('a1000000-0000-0000-0000-000000000007', 'Quinto examen departamental', 'ADMIN', '2026-05-11', '2026-05-15', TRUE, FALSE, TRUE, 19),
+('a1000000-0000-0000-0000-000000000007', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, TRUE, TRUE, 20),
+('a1000000-0000-0000-0000-000000000007', 'Sexto examen departamental', 'ADMIN', '2026-06-08', '2026-06-12', TRUE, FALSE, TRUE, 21),
+('a1000000-0000-0000-0000-000000000007', 'Periodo ETS - Semestre 2', 'ADMIN', '2026-06-22', '2026-06-26', TRUE, FALSE, FALSE, 22);
+
+-- Template: Preparatoria/Bachillerato Privado sin incorporacion 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000008', 'MEDIA_SUPERIOR_PRIVADO_2025_2026', 'Calendario Media Superior Privado 2025-2026', 'Calendario flexible para bachilleratos privados sin incorporacion. Solo dias festivos oficiales.', '2025-2026', 'ANNUAL', 'NONE', 'MEDIA_SUPERIOR', FALSE, NULL, '2025-08-18', '2026-07-10', 190);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000008', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000008', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 2),
+('a1000000-0000-0000-0000-000000000008', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 3),
+('a1000000-0000-0000-0000-000000000008', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-09', TRUE, TRUE, FALSE, 4),
+('a1000000-0000-0000-0000-000000000008', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 5),
+('a1000000-0000-0000-0000-000000000008', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000008', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 7),
+('a1000000-0000-0000-0000-000000000008', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 8),
+('a1000000-0000-0000-0000-000000000008', 'Vacaciones de Semana Santa', 'VACATION', '2026-03-30', '2026-04-10', TRUE, TRUE, FALSE, 9),
+('a1000000-0000-0000-0000-000000000008', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 10),
+('a1000000-0000-0000-0000-000000000008', 'Batalla de Puebla', 'HOLIDAY', '2026-05-05', '2026-05-05', TRUE, TRUE, TRUE, 11),
+('a1000000-0000-0000-0000-000000000008', 'Dia del Maestro', 'SUSPENSION', '2026-05-15', '2026-05-15', TRUE, TRUE, TRUE, 12);
+
+-- Template: Inicial (guarderia educativa / CENDI) 2025-2026
+INSERT INTO calendar_templates (id, code, name, description, year_label, period_type, authority, applicable_levels, requires_accreditation, accreditation_authority, start_date, end_date, expected_class_days)
+VALUES ('a1000000-0000-0000-0000-000000000009', 'INICIAL_2025_2026', 'Calendario Educacion Inicial 2025-2026', 'Calendario para centros de educacion inicial (CENDI, guarderias educativas). Operacion continua con dias festivos oficiales.', '2025-2026', 'ANNUAL', 'NONE', 'INICIAL', FALSE, NULL, '2025-08-18', '2026-08-14', 240);
+
+INSERT INTO calendar_template_events (template_id, name, event_type, start_date, end_date, affects_classes, affects_staff, is_mandatory, sort_order) VALUES
+('a1000000-0000-0000-0000-000000000009', 'Dia de la Independencia', 'HOLIDAY', '2025-09-16', '2025-09-16', TRUE, TRUE, TRUE, 1),
+('a1000000-0000-0000-0000-000000000009', 'Dia de Muertos', 'SUSPENSION', '2025-11-03', '2025-11-03', TRUE, FALSE, FALSE, 2),
+('a1000000-0000-0000-0000-000000000009', 'Revolucion Mexicana', 'HOLIDAY', '2025-11-17', '2025-11-17', TRUE, TRUE, TRUE, 3),
+('a1000000-0000-0000-0000-000000000009', 'Dia de la Virgen de Guadalupe', 'SUSPENSION', '2025-12-12', '2025-12-12', TRUE, FALSE, FALSE, 4),
+('a1000000-0000-0000-0000-000000000009', 'Vacaciones de invierno', 'VACATION', '2025-12-22', '2026-01-06', TRUE, TRUE, FALSE, 5),
+('a1000000-0000-0000-0000-000000000009', 'Navidad', 'HOLIDAY', '2025-12-25', '2025-12-25', TRUE, TRUE, TRUE, 6),
+('a1000000-0000-0000-0000-000000000009', 'Ano Nuevo', 'HOLIDAY', '2026-01-01', '2026-01-01', TRUE, TRUE, TRUE, 7),
+('a1000000-0000-0000-0000-000000000009', 'Dia de la Constitucion', 'HOLIDAY', '2026-02-02', '2026-02-02', TRUE, TRUE, TRUE, 8),
+('a1000000-0000-0000-0000-000000000009', 'Natalicio de Benito Juarez', 'HOLIDAY', '2026-03-16', '2026-03-16', TRUE, TRUE, TRUE, 9),
+('a1000000-0000-0000-0000-000000000009', 'Semana Santa', 'VACATION', '2026-04-02', '2026-04-03', TRUE, TRUE, FALSE, 10),
+('a1000000-0000-0000-0000-000000000009', 'Dia del Nino', 'SUSPENSION', '2026-04-30', '2026-04-30', TRUE, FALSE, FALSE, 11),
+('a1000000-0000-0000-0000-000000000009', 'Dia del Trabajo', 'HOLIDAY', '2026-05-01', '2026-05-01', TRUE, TRUE, TRUE, 12);

--- a/didacta-web/package-lock.json
+++ b/didacta-web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "keycloak-js": "^26.2.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2115,6 +2116,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/didacta-web/package.json
+++ b/didacta-web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "keycloak-js": "^26.2.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/didacta-web/src/App.tsx
+++ b/didacta-web/src/App.tsx
@@ -6,6 +6,7 @@ import AuthGuard from './components/AuthGuard';
 import Step0Welcome from './views/onboarding/Step0Welcome';
 import Step1Institution from './views/onboarding/Step1Institution';
 import Step2InviteUser from './views/onboarding/Step2InviteUser';
+import CalendarView from './views/settings/CalendarView';
 
 export default function App() {
   return (
@@ -17,6 +18,12 @@ export default function App() {
           <Route path="/dashboard" element={
             <DashboardLayout>
               <DashboardView />
+            </DashboardLayout>
+          } />
+
+          <Route path="/settings/calendar" element={
+            <DashboardLayout>
+              <CalendarView />
             </DashboardLayout>
           } />
 

--- a/didacta-web/src/components/calendar/CalendarDayCell.tsx
+++ b/didacta-web/src/components/calendar/CalendarDayCell.tsx
@@ -1,0 +1,96 @@
+import { parseISO, startOfWeek, isSameDay, isWeekend } from 'date-fns';
+import type { CalendarEvent } from '../../hooks/useCalendarEvents';
+import { getEventColors, getEventPriority } from './CalendarEventDot';
+
+interface CalendarDayCellProps {
+  date: Date;
+  isToday: boolean;
+  isCurrentMonth: boolean;
+  events: CalendarEvent[];
+  onDayClick: (date: Date) => void;
+  onEventClick: (event: CalendarEvent) => void;
+}
+
+export default function CalendarDayCell({
+  date,
+  isToday,
+  isCurrentMonth,
+  events,
+  onDayClick,
+  onEventClick,
+}: CalendarDayCellProps) {
+  const dayNumber = date.getDate();
+  const weekend = isWeekend(date);
+
+  // Sort events by priority (most important first)
+  const sorted = [...events].sort(
+    (a, b) => getEventPriority(a.eventType) - getEventPriority(b.eventType)
+  );
+
+  const topEvent = sorted.length > 0 ? sorted[0] : null;
+  const remaining = sorted.length > 1 ? sorted.length - 1 : 0;
+
+  // Determine cell background and border
+  let cellBg = weekend ? 'bg-gray-50' : 'bg-white';
+  let borderL = '';
+
+  if (topEvent) {
+    const colors = getEventColors(topEvent.eventType);
+    cellBg = colors.cellBg;
+    borderL = colors.borderL;
+  }
+
+  // For multi-day events, only show name on first day visible in that week
+  let showEventName = false;
+  if (topEvent) {
+    const eventStart = parseISO(topEvent.startDate);
+    const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+    // Show name if this day IS the event start, or it's the first day of the week within the range
+    showEventName = isSameDay(date, eventStart) || isSameDay(date, weekStart);
+  }
+
+  const opacityClass = !isCurrentMonth ? 'opacity-30' : '';
+
+  return (
+    <button
+      onClick={() => {
+        if (topEvent) {
+          onEventClick(topEvent);
+        } else {
+          onDayClick(date);
+        }
+      }}
+      className={`min-h-[80px] sm:min-h-[100px] p-1 sm:p-2 border-b border-r border-gray-100 text-left transition-colors hover:brightness-95 flex flex-col ${cellBg} ${borderL} ${opacityClass}`}
+    >
+      {/* Day number */}
+      <div className="flex justify-start mb-1">
+        <span
+          className={`text-sm font-medium inline-flex items-center justify-center ${
+            isToday
+              ? 'bg-blue-600 text-white rounded-full w-7 h-7'
+              : isCurrentMonth
+                ? 'text-gray-900 w-7 h-7'
+                : 'text-gray-400 w-7 h-7'
+          }`}
+        >
+          {dayNumber}
+        </span>
+      </div>
+
+      {/* Event label */}
+      <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+        {topEvent && showEventName && (
+          <span
+            className={`text-xs truncate font-medium ${getEventColors(topEvent.eventType).text}`}
+            title={topEvent.name}
+          >
+            {topEvent.name}
+          </span>
+        )}
+        {remaining > 0 && (
+          <span className="text-xs text-gray-500 font-medium">+{remaining}</span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarEventDetail.tsx
+++ b/didacta-web/src/components/calendar/CalendarEventDetail.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef } from 'react';
+import { format, parseISO, isSameDay } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { CalendarEvent } from '../../hooks/useCalendarEvents';
+import { getEventColors } from './CalendarEventDot';
+
+interface CalendarEventDetailProps {
+  event: CalendarEvent | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: (event: CalendarEvent) => void;
+  onDelete: (event: CalendarEvent) => void;
+}
+
+const EVENT_TYPE_LABELS: Record<string, string> = {
+  HOLIDAY: 'Festivo',
+  VACATION: 'Vacaciones',
+  CTE: 'CTE',
+  ADMIN: 'Administrativo',
+  SUSPENSION: 'Suspension',
+  CUSTOM: 'Personalizado',
+};
+
+export default function CalendarEventDetail({
+  event,
+  isOpen,
+  onClose,
+  onEdit,
+  onDelete,
+}: CalendarEventDetailProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleEsc);
+    }
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !event) return null;
+
+  const colors = getEventColors(event.eventType);
+  const start = parseISO(event.startDate);
+  const end = parseISO(event.endDate);
+  const isMultiDay = !isSameDay(start, end);
+  const canModify = !event.isFromTemplate || !event.mandatory;
+
+  const dateLabel = isMultiDay
+    ? `${format(start, "d 'de' MMMM yyyy", { locale: es })} - ${format(end, "d 'de' MMMM yyyy", { locale: es })}`
+    : format(start, "d 'de' MMMM yyyy", { locale: es });
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 z-40 bg-black/20 transition-opacity duration-300"
+        onClick={onClose}
+      />
+
+      {/* Slide-in panel */}
+      <div
+        ref={panelRef}
+        className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-96 bg-white shadow-xl transform transition-transform duration-300 translate-x-0 flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-100">
+          <h3 className="text-lg font-semibold text-gray-900">Detalle del evento</h3>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* Name */}
+          <div>
+            <h4 className="text-xl font-bold text-gray-900">{event.name}</h4>
+          </div>
+
+          {/* Type badge */}
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Tipo</span>
+            <div className="mt-1">
+              <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm font-medium ${colors.text}`}>
+                <span className={`w-2 h-2 rounded-full ${colors.dot}`} />
+                {EVENT_TYPE_LABELS[event.eventType] ?? event.eventType}
+              </span>
+            </div>
+          </div>
+
+          {/* Dates */}
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Fecha</span>
+            <p className="text-sm text-gray-900 mt-1">{dateLabel}</p>
+          </div>
+
+          {/* Affects */}
+          <div className="flex gap-4">
+            <div className="flex items-center gap-2">
+              <span className={`w-5 h-5 rounded flex items-center justify-center ${event.affectsClasses ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-400'}`}>
+                {event.affectsClasses ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                )}
+              </span>
+              <span className="text-sm text-gray-700">Afecta clases</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className={`w-5 h-5 rounded flex items-center justify-center ${event.affectsStaff ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-400'}`}>
+                {event.affectsStaff ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                )}
+              </span>
+              <span className="text-sm text-gray-700">Afecta personal</span>
+            </div>
+          </div>
+
+          {/* Notes */}
+          {event.notes && (
+            <div>
+              <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Notas</span>
+              <p className="text-sm text-gray-700 mt-1 whitespace-pre-wrap">{event.notes}</p>
+            </div>
+          )}
+
+          {/* Template indicator */}
+          {event.isFromTemplate && (
+            <div className="flex items-center gap-2 text-sm text-gray-500 bg-gray-50 rounded-lg p-3">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+              <span>Este evento proviene de la plantilla oficial</span>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        {canModify && !event.isFromTemplate && (
+          <div className="p-6 border-t border-gray-100 flex gap-3">
+            <button
+              onClick={() => onEdit(event)}
+              className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              Editar
+            </button>
+            <button
+              onClick={() => onDelete(event)}
+              className="border border-red-300 text-red-600 px-4 py-2 rounded-lg hover:bg-red-50 transition-colors text-sm font-medium"
+            >
+              Eliminar
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarEventDot.tsx
+++ b/didacta-web/src/components/calendar/CalendarEventDot.tsx
@@ -1,0 +1,125 @@
+import type { CalendarEventType } from '../../hooks/useCalendarEvents';
+
+interface CalendarEventDotProps {
+  name: string;
+  eventType: CalendarEventType;
+  onClick: () => void;
+}
+
+export interface EventColorConfig {
+  dot: string;
+  text: string;
+  bg: string;
+  cellBg: string;
+  borderL: string;
+  badgeBg: string;
+  badgeText: string;
+}
+
+const EVENT_COLORS: Record<CalendarEventType, EventColorConfig> = {
+  HOLIDAY: {
+    dot: 'bg-red-500',
+    text: 'text-red-700',
+    bg: 'hover:bg-red-50',
+    cellBg: 'bg-red-100',
+    borderL: 'border-l-4 border-l-red-500',
+    badgeBg: 'bg-red-100',
+    badgeText: 'text-red-700',
+  },
+  VACATION: {
+    dot: 'bg-blue-500',
+    text: 'text-blue-700',
+    bg: 'hover:bg-blue-50',
+    cellBg: 'bg-blue-100',
+    borderL: 'border-l-4 border-l-blue-500',
+    badgeBg: 'bg-blue-100',
+    badgeText: 'text-blue-700',
+  },
+  CTE: {
+    dot: 'bg-amber-500',
+    text: 'text-amber-700',
+    bg: 'hover:bg-amber-50',
+    cellBg: 'bg-amber-100',
+    borderL: 'border-l-4 border-l-amber-500',
+    badgeBg: 'bg-amber-100',
+    badgeText: 'text-amber-700',
+  },
+  SUSPENSION: {
+    dot: 'bg-orange-400',
+    text: 'text-orange-700',
+    bg: 'hover:bg-orange-50',
+    cellBg: 'bg-orange-100',
+    borderL: 'border-l-4 border-l-orange-400',
+    badgeBg: 'bg-orange-100',
+    badgeText: 'text-orange-700',
+  },
+  ADMIN: {
+    dot: 'bg-emerald-500',
+    text: 'text-emerald-700',
+    bg: 'hover:bg-emerald-50',
+    cellBg: 'bg-emerald-50',
+    borderL: '',
+    badgeBg: 'bg-emerald-100',
+    badgeText: 'text-emerald-700',
+  },
+  CUSTOM: {
+    dot: 'bg-purple-500',
+    text: 'text-purple-700',
+    bg: 'hover:bg-purple-50',
+    cellBg: 'bg-purple-50',
+    borderL: '',
+    badgeBg: 'bg-purple-100',
+    badgeText: 'text-purple-700',
+  },
+};
+
+/** Priority order: lower index = higher priority */
+const EVENT_TYPE_PRIORITY: CalendarEventType[] = [
+  'HOLIDAY',
+  'VACATION',
+  'CTE',
+  'SUSPENSION',
+  'ADMIN',
+  'CUSTOM',
+];
+
+export function getEventColors(eventType: CalendarEventType): EventColorConfig {
+  return EVENT_COLORS[eventType] ?? EVENT_COLORS.CUSTOM;
+}
+
+export function getEventPriority(eventType: CalendarEventType): number {
+  const idx = EVENT_TYPE_PRIORITY.indexOf(eventType);
+  return idx >= 0 ? idx : EVENT_TYPE_PRIORITY.length;
+}
+
+export const EVENT_TYPE_LABELS: Record<CalendarEventType, string> = {
+  HOLIDAY: 'Festivo',
+  VACATION: 'Vacaciones',
+  CTE: 'CTE',
+  SUSPENSION: 'Suspension',
+  ADMIN: 'Administrativo',
+  CUSTOM: 'Personalizado',
+};
+
+export const ALL_EVENT_TYPES: CalendarEventType[] = [
+  'HOLIDAY',
+  'VACATION',
+  'CTE',
+  'SUSPENSION',
+  'ADMIN',
+  'CUSTOM',
+];
+
+export default function CalendarEventDot({ name, eventType, onClick }: CalendarEventDotProps) {
+  const colors = getEventColors(eventType);
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      className={`flex items-center gap-1 w-full px-1 py-0.5 rounded cursor-pointer transition-colors ${colors.bg}`}
+    >
+      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${colors.dot}`} />
+      <span className={`text-xs truncate ${colors.text}`}>{name}</span>
+    </button>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarEventForm.tsx
+++ b/didacta-web/src/components/calendar/CalendarEventForm.tsx
@@ -1,0 +1,251 @@
+import { useState, useEffect, useRef } from 'react';
+import { format } from 'date-fns';
+import type { CalendarEvent, CalendarEventType, CreateEventPayload } from '../../hooks/useCalendarEvents';
+
+interface CalendarEventFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (payload: CreateEventPayload) => Promise<void>;
+  event?: CalendarEvent | null;
+  defaultDate?: Date | null;
+}
+
+const EVENT_TYPE_OPTIONS: { value: CalendarEventType; label: string }[] = [
+  { value: 'HOLIDAY', label: 'Festivo' },
+  { value: 'VACATION', label: 'Vacaciones' },
+  { value: 'SUSPENSION', label: 'Suspension' },
+  { value: 'ADMIN', label: 'Administrativo' },
+  { value: 'CUSTOM', label: 'Personalizado' },
+];
+
+export default function CalendarEventForm({
+  isOpen,
+  onClose,
+  onSave,
+  event,
+  defaultDate,
+}: CalendarEventFormProps) {
+  const [name, setName] = useState('');
+  const [eventType, setEventType] = useState<CalendarEventType>('CUSTOM');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [affectsClasses, setAffectsClasses] = useState(true);
+  const [affectsStaff, setAffectsStaff] = useState(false);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (event) {
+        setName(event.name);
+        setEventType(event.eventType);
+        setStartDate(event.startDate);
+        setEndDate(event.endDate);
+        setAffectsClasses(event.affectsClasses);
+        setAffectsStaff(event.affectsStaff);
+        setNotes(event.notes ?? '');
+      } else {
+        const dateStr = defaultDate ? format(defaultDate, 'yyyy-MM-dd') : format(new Date(), 'yyyy-MM-dd');
+        setName('');
+        setEventType('CUSTOM');
+        setStartDate(dateStr);
+        setEndDate(dateStr);
+        setAffectsClasses(true);
+        setAffectsStaff(false);
+        setNotes('');
+      }
+      setErrors({});
+    }
+  }, [isOpen, event, defaultDate]);
+
+  const validate = (): boolean => {
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = 'El nombre es requerido';
+    if (!startDate) errs.startDate = 'La fecha de inicio es requerida';
+    if (!endDate) errs.endDate = 'La fecha de fin es requerida';
+    if (startDate && endDate && startDate > endDate) {
+      errs.endDate = 'La fecha de fin debe ser igual o posterior a la de inicio';
+    }
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setSaving(true);
+    try {
+      await onSave({
+        name: name.trim(),
+        eventType,
+        startDate,
+        endDate,
+        affectsClasses,
+        affectsStaff,
+        notes: notes.trim() || undefined,
+      });
+      onClose();
+    } catch (err) {
+      console.error('Error al guardar evento:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 animate-fade-in"
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg transform transition-all duration-200 animate-scale-in">
+        <div className="flex items-center justify-between p-6 border-b border-gray-100">
+          <h3 className="text-lg font-semibold text-gray-900">
+            {event ? 'Editar evento' : 'Nuevo evento'}
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nombre del evento *
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors ${
+                errors.name ? 'border-red-300' : 'border-gray-300'
+              }`}
+              placeholder="Ej: Dia de la Independencia"
+            />
+            {errors.name && <p className="text-xs text-red-500 mt-1">{errors.name}</p>}
+          </div>
+
+          {/* Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Tipo de evento
+            </label>
+            <select
+              value={eventType}
+              onChange={e => setEventType(e.target.value as CalendarEventType)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors"
+            >
+              {EVENT_TYPE_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Dates */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Fecha inicio *
+              </label>
+              <input
+                type="date"
+                value={startDate}
+                onChange={e => {
+                  setStartDate(e.target.value);
+                  if (!endDate || e.target.value > endDate) {
+                    setEndDate(e.target.value);
+                  }
+                }}
+                className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors ${
+                  errors.startDate ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.startDate && <p className="text-xs text-red-500 mt-1">{errors.startDate}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Fecha fin *
+              </label>
+              <input
+                type="date"
+                value={endDate}
+                onChange={e => setEndDate(e.target.value)}
+                className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors ${
+                  errors.endDate ? 'border-red-300' : 'border-gray-300'
+                }`}
+              />
+              {errors.endDate && <p className="text-xs text-red-500 mt-1">{errors.endDate}</p>}
+            </div>
+          </div>
+
+          {/* Checkboxes */}
+          <div className="flex gap-6">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={affectsClasses}
+                onChange={e => setAffectsClasses(e.target.checked)}
+                className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm text-gray-700">Afecta clases</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={affectsStaff}
+                onChange={e => setAffectsStaff(e.target.checked)}
+                className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm text-gray-700">Afecta personal</span>
+            </label>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Notas (opcional)
+            </label>
+            <textarea
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors resize-none"
+              placeholder="Notas adicionales sobre el evento..."
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium disabled:opacity-50"
+            >
+              {saving ? 'Guardando...' : 'Guardar'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarHeader.tsx
+++ b/didacta-web/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,147 @@
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { CalendarViewMode } from '../../hooks/useCalendarNavigation';
+import type { CalendarEventType } from '../../hooks/useCalendarEvents';
+import { getEventColors, EVENT_TYPE_LABELS, ALL_EVENT_TYPES } from './CalendarEventDot';
+
+interface CalendarHeaderProps {
+  currentDate: Date;
+  view: CalendarViewMode;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  onToday: () => void;
+  onViewChange: (view: CalendarViewMode) => void;
+  calendarName: string;
+  onAddEvent: () => void;
+  activeFilters: Set<CalendarEventType>;
+  onToggleFilter: (type: CalendarEventType) => void;
+}
+
+export default function CalendarHeader({
+  currentDate,
+  view,
+  onPrevMonth,
+  onNextMonth,
+  onToday,
+  onViewChange,
+  calendarName,
+  onAddEvent,
+  activeFilters,
+  onToggleFilter,
+}: CalendarHeaderProps) {
+  const monthLabel = format(currentDate, 'MMMM yyyy', { locale: es });
+  const capitalizedMonth = monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+
+  return (
+    <div className="mb-6 space-y-4">
+      {/* Top row: name, navigation, actions */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        {/* Left: Calendar name */}
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-gray-900">{calendarName}</h2>
+        </div>
+
+        {/* Center: Navigation */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onPrevMonth}
+            className="p-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors"
+            title="Mes anterior"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+          </button>
+          <button
+            onClick={onToday}
+            className="px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            Hoy
+          </button>
+          <button
+            onClick={onNextMonth}
+            className="p-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors"
+            title="Mes siguiente"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+          </button>
+          <span className="text-sm font-semibold text-gray-800 min-w-[140px] text-center">
+            {capitalizedMonth}
+          </span>
+        </div>
+
+        {/* Right: View toggle + Add */}
+        <div className="flex items-center gap-3">
+          {/* View toggle */}
+          <div className="bg-gray-100 rounded-lg p-1 flex">
+            <button
+              onClick={() => onViewChange('month')}
+              className={`px-3 py-1 text-sm font-medium rounded-md transition-all duration-200 ${
+                view === 'month'
+                  ? 'bg-white shadow-sm text-gray-900'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Mes
+            </button>
+            <button
+              onClick={() => onViewChange('list')}
+              className={`px-3 py-1 text-sm font-medium rounded-md transition-all duration-200 ${
+                view === 'list'
+                  ? 'bg-white shadow-sm text-gray-900'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Lista
+            </button>
+          </div>
+
+          {/* Add event */}
+          <button
+            onClick={onAddEvent}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium flex items-center gap-2"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+            <span className="hidden sm:inline">Agregar evento</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Filter chips */}
+      <div className="flex flex-wrap items-center gap-2">
+        {ALL_EVENT_TYPES.map(type => {
+          const colors = getEventColors(type);
+          const isActive = activeFilters.has(type);
+          return (
+            <button
+              key={type}
+              onClick={() => onToggleFilter(type)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border transition-all duration-150 ${
+                isActive
+                  ? `${colors.badgeBg} ${colors.badgeText} border-transparent`
+                  : 'bg-gray-100 text-gray-400 border-gray-200 line-through'
+              }`}
+            >
+              <span className={`w-2 h-2 rounded-full ${isActive ? colors.dot : 'bg-gray-300'}`} />
+              {EVENT_TYPE_LABELS[type]}
+              {isActive && (
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-4">
+        {ALL_EVENT_TYPES.map(type => {
+          const colors = getEventColors(type);
+          return (
+            <div key={type} className="flex items-center gap-1.5">
+              <span className={`w-2.5 h-2.5 rounded-full ${colors.dot}`} />
+              <span className="text-xs text-gray-600">{EVENT_TYPE_LABELS[type]}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarListView.tsx
+++ b/didacta-web/src/components/calendar/CalendarListView.tsx
@@ -1,0 +1,201 @@
+import { format, parseISO, isSameDay } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { CalendarEvent } from '../../hooks/useCalendarEvents';
+import { getEventColors, EVENT_TYPE_LABELS } from './CalendarEventDot';
+
+interface CalendarListViewProps {
+  events: CalendarEvent[];
+  onEventClick: (event: CalendarEvent) => void;
+  onEditEvent: (event: CalendarEvent) => void;
+  onDeleteEvent: (event: CalendarEvent) => void;
+}
+
+function LockIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-gray-400 flex-shrink-0"
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+function EventTypeIcon({ eventType }: { eventType: string }) {
+  const iconClass = 'flex-shrink-0';
+  switch (eventType) {
+    case 'HOLIDAY':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+      );
+    case 'VACATION':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
+      );
+    case 'CTE':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+      );
+    case 'SUSPENSION':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+      );
+    case 'ADMIN':
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+      );
+    default:
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={iconClass}><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+      );
+  }
+}
+
+export default function CalendarListView({
+  events,
+  onEventClick,
+  onEditEvent,
+  onDeleteEvent,
+}: CalendarListViewProps) {
+  // Filter deleted events
+  const activeEvents = events.filter(e => !e.deleted);
+
+  // Sort by start date ascending
+  const sorted = [...activeEvents].sort(
+    (a, b) => parseISO(a.startDate).getTime() - parseISO(b.startDate).getTime()
+  );
+
+  // Group by month
+  const groups: Record<string, CalendarEvent[]> = {};
+  for (const event of sorted) {
+    const key = format(parseISO(event.startDate), 'yyyy-MM');
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(event);
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-12 text-center">
+        <p className="text-gray-500">No hay eventos en este calendario.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {Object.entries(groups).map(([monthKey, monthEvents]) => {
+        const monthDate = parseISO(`${monthKey}-01`);
+        const monthLabel = format(monthDate, 'MMMM yyyy', { locale: es });
+        const capitalizedMonth = monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+
+        return (
+          <div key={monthKey}>
+            <div className="flex items-center gap-3 mb-3">
+              <h3 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">
+                {capitalizedMonth}
+              </h3>
+              <div className="flex-1 h-px bg-gray-200" />
+              <span className="text-xs text-gray-400">{monthEvents.length} evento{monthEvents.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 divide-y divide-gray-100 overflow-hidden">
+              {monthEvents.map(event => (
+                <EventRow
+                  key={event.id}
+                  event={event}
+                  onClick={() => onEventClick(event)}
+                  onEdit={() => onEditEvent(event)}
+                  onDelete={() => onDeleteEvent(event)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EventRow({
+  event,
+  onClick,
+  onEdit,
+  onDelete,
+}: {
+  event: CalendarEvent;
+  onClick: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const colors = getEventColors(event.eventType);
+  const start = parseISO(event.startDate);
+  const end = parseISO(event.endDate);
+  const isMultiDay = !isSameDay(start, end);
+
+  const dateLabel = isMultiDay
+    ? `${format(start, 'd MMM yyyy', { locale: es })} - ${format(end, 'd MMM yyyy', { locale: es })}`
+    : format(start, 'd MMM yyyy', { locale: es });
+
+  return (
+    <div
+      onClick={onClick}
+      className="flex items-center gap-3 sm:gap-4 px-4 py-3 hover:bg-gray-50 cursor-pointer transition-colors group"
+    >
+      {/* Color bar */}
+      <div className={`w-1 h-12 rounded-full flex-shrink-0 ${colors.dot}`} />
+
+      {/* Icon */}
+      <div className={`flex-shrink-0 ${colors.text}`}>
+        <EventTypeIcon eventType={event.eventType} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <span className="text-sm font-medium text-gray-900 truncate">{event.name}</span>
+          {event.isFromTemplate && <LockIcon />}
+        </div>
+        <span className="text-xs text-gray-500">{dateLabel}</span>
+      </div>
+
+      {/* Type badge */}
+      <span className={`hidden sm:inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium flex-shrink-0 ${colors.badgeBg} ${colors.badgeText}`}>
+        {EVENT_TYPE_LABELS[event.eventType] ?? event.eventType}
+      </span>
+
+      {/* Actions */}
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+        {event.isFromTemplate ? (
+          <span className="p-1.5 text-gray-400" title="Evento de plantilla">
+            <LockIcon />
+          </span>
+        ) : (
+          <>
+            <button
+              onClick={(e) => { e.stopPropagation(); onEdit(); }}
+              className="p-1.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+              title="Editar"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+              title="Eliminar"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/calendar/CalendarMonthGrid.tsx
+++ b/didacta-web/src/components/calendar/CalendarMonthGrid.tsx
@@ -1,0 +1,81 @@
+import {
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  isSameMonth,
+  isToday,
+  parseISO,
+  isWithinInterval,
+} from 'date-fns';
+import type { CalendarEvent } from '../../hooks/useCalendarEvents';
+import CalendarDayCell from './CalendarDayCell';
+
+interface CalendarMonthGridProps {
+  currentDate: Date;
+  events: CalendarEvent[];
+  onDayClick: (date: Date) => void;
+  onEventClick: (event: CalendarEvent) => void;
+}
+
+const WEEKDAY_LABELS = ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom'];
+
+function getEventsForDay(events: CalendarEvent[], day: Date): CalendarEvent[] {
+  return events.filter(event => {
+    const start = parseISO(event.startDate);
+    const end = parseISO(event.endDate);
+    return isWithinInterval(day, { start, end });
+  });
+}
+
+export default function CalendarMonthGrid({
+  currentDate,
+  events,
+  onDayClick,
+  onEventClick,
+}: CalendarMonthGridProps) {
+  const monthStart = startOfMonth(currentDate);
+  const monthEnd = endOfMonth(currentDate);
+  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 1 });
+  const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
+
+  const days = eachDayOfInterval({ start: calendarStart, end: calendarEnd });
+
+  // Filter out deleted events
+  const activeEvents = events.filter(e => !e.deleted);
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden transition-opacity duration-200">
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 border-b border-gray-200">
+        {WEEKDAY_LABELS.map(label => (
+          <div
+            key={label}
+            className="py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wide"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7">
+        {days.map(day => {
+          const dayEvents = getEventsForDay(activeEvents, day);
+          return (
+            <CalendarDayCell
+              key={day.toISOString()}
+              date={day}
+              isToday={isToday(day)}
+              isCurrentMonth={isSameMonth(day, currentDate)}
+              events={dayEvents}
+              onDayClick={onDayClick}
+              onEventClick={onEventClick}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/hooks/useCalendarEvents.ts
+++ b/didacta-web/src/hooks/useCalendarEvents.ts
@@ -1,0 +1,102 @@
+import { useState, useCallback } from 'react';
+import api from '../api/didactaApi';
+
+export type CalendarEventType = 'HOLIDAY' | 'VACATION' | 'CTE' | 'ADMIN' | 'SUSPENSION' | 'CUSTOM';
+
+export interface CalendarEvent {
+  id: string;
+  calendarId: string;
+  name: string;
+  eventType: CalendarEventType;
+  startDate: string;
+  endDate: string;
+  affectsClasses: boolean;
+  affectsStaff: boolean;
+  notes: string | null;
+  isFromTemplate: boolean;
+  mandatory: boolean;
+  deleted: boolean;
+}
+
+export interface CalendarData {
+  id: string;
+  name: string;
+  status: string;
+  sectionId: string;
+}
+
+export interface CreateEventPayload {
+  name: string;
+  eventType: CalendarEventType;
+  startDate: string;
+  endDate: string;
+  affectsClasses: boolean;
+  affectsStaff: boolean;
+  notes?: string;
+}
+
+export function useCalendarEvents() {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [calendars, setCalendars] = useState<CalendarData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCalendars = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await api.get<CalendarData[]>('/api/calendars');
+      setCalendars(res.data);
+      return res.data;
+    } catch (err) {
+      setError('Error al cargar calendarios');
+      console.error(err);
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchEvents = useCallback(async (calendarId: string) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await api.get<{ calendar: CalendarData; events: CalendarEvent[] }>(`/api/calendars/${calendarId}`);
+      setEvents(res.data.events ?? []);
+    } catch (err) {
+      setError('Error al cargar eventos');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const createEvent = useCallback(async (calendarId: string, payload: CreateEventPayload) => {
+    const res = await api.post<CalendarEvent>(`/api/calendars/${calendarId}/events`, payload);
+    setEvents(prev => [...prev, res.data]);
+    return res.data;
+  }, []);
+
+  const updateEvent = useCallback(async (calendarId: string, eventId: string, payload: CreateEventPayload) => {
+    const res = await api.patch<CalendarEvent>(`/api/calendars/${calendarId}/events/${eventId}`, payload);
+    setEvents(prev => prev.map(e => e.id === eventId ? res.data : e));
+    return res.data;
+  }, []);
+
+  const deleteEvent = useCallback(async (calendarId: string, eventId: string) => {
+    await api.delete(`/api/calendars/${calendarId}/events/${eventId}`);
+    setEvents(prev => prev.filter(e => e.id !== eventId));
+  }, []);
+
+  return {
+    events,
+    calendars,
+    loading,
+    error,
+    fetchCalendars,
+    fetchEvents,
+    createEvent,
+    updateEvent,
+    deleteEvent,
+  };
+}

--- a/didacta-web/src/hooks/useCalendarNavigation.ts
+++ b/didacta-web/src/hooks/useCalendarNavigation.ts
@@ -1,0 +1,30 @@
+import { useState, useCallback } from 'react';
+import { addMonths, subMonths, startOfToday } from 'date-fns';
+
+export type CalendarViewMode = 'month' | 'list';
+
+export function useCalendarNavigation() {
+  const [currentDate, setCurrentDate] = useState<Date>(startOfToday());
+  const [view, setView] = useState<CalendarViewMode>('month');
+
+  const goToPrevMonth = useCallback(() => {
+    setCurrentDate(prev => subMonths(prev, 1));
+  }, []);
+
+  const goToNextMonth = useCallback(() => {
+    setCurrentDate(prev => addMonths(prev, 1));
+  }, []);
+
+  const goToToday = useCallback(() => {
+    setCurrentDate(startOfToday());
+  }, []);
+
+  return {
+    currentDate,
+    view,
+    setView,
+    goToPrevMonth,
+    goToNextMonth,
+    goToToday,
+  };
+}

--- a/didacta-web/src/index.css
+++ b/didacta-web/src/index.css
@@ -6,3 +6,21 @@ body {
   background-color: #f3f4f6;
   /* Gray-100 */
 }
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.2s ease-out;
+}
+
+.animate-scale-in {
+  animation: scale-in 0.2s ease-out;
+}

--- a/didacta-web/src/views/DashboardLayout.tsx
+++ b/didacta-web/src/views/DashboardLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import keycloak from '../auth/keycloak';
 
 interface DashboardLayoutProps {
@@ -6,6 +7,8 @@ interface DashboardLayoutProps {
 }
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
+    const navigate = useNavigate();
+    const location = useLocation();
     const [userProfile, setUserProfile] = useState<{ name: string; email: string }>({ name: '', email: '' });
 
     useEffect(() => {
@@ -16,6 +19,8 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             setUserProfile({ name, email });
         }
     }, []);
+
+    const isActive = (path: string) => location.pathname === path || location.pathname.startsWith(path + '/');
 
     return (
         <div className="flex h-screen bg-gray-50 overflow-hidden">
@@ -29,19 +34,23 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 {/* Nav Items */}
                 <nav className="flex-1 flex flex-col gap-1 px-3 mt-4">
                     <NavItem
-                        active
+                        active={isActive('/dashboard')}
                         label="Dashboard"
+                        onClick={() => navigate('/dashboard')}
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>}
                     />
                     <NavItem
+                        active={false}
                         label="Sesiones"
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>}
                     />
                     <NavItem
+                        active={false}
                         label="Alumnos"
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>}
                     />
                     <NavItem
+                        active={false}
                         label="Recursos"
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>}
                     />
@@ -53,7 +62,9 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                         <span className="text-xs font-bold text-gray-400 uppercase tracking-widest">Cuenta</span>
                     </div>
                     <NavItem
-                        label="Configuración"
+                        active={isActive('/settings')}
+                        label="Configuracion"
+                        onClick={() => navigate('/settings/calendar')}
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>}
                     />
 
@@ -87,9 +98,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     );
 }
 
-function NavItem({ icon, label, active = false }: { icon: React.ReactNode; label: string; active?: boolean }) {
+function NavItem({ icon, label, active = false, onClick }: { icon: React.ReactNode; label: string; active?: boolean; onClick?: () => void }) {
     return (
         <button
+            onClick={onClick}
             className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 text-sm font-medium ${active
                 ? 'bg-blue-50 text-blue-700'
                 : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900'

--- a/didacta-web/src/views/onboarding/Step1Institution.tsx
+++ b/didacta-web/src/views/onboarding/Step1Institution.tsx
@@ -116,6 +116,8 @@ export default function Step1Institution() {
             if (response.data && response.data.institutionId) {
                 localStorage.setItem('didacta_institution_id', response.data.institutionId);
             }
+            // Second call: create sections & calendars (requires X-Institution-Id header)
+            await api.post('/api/onboarding/setup', payload);
             navigate('/onboarding/step-2');
         } catch (err) {
             console.error(err);

--- a/didacta-web/src/views/settings/CalendarView.tsx
+++ b/didacta-web/src/views/settings/CalendarView.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useCalendarNavigation } from '../../hooks/useCalendarNavigation';
+import { useCalendarEvents } from '../../hooks/useCalendarEvents';
+import type { CalendarEvent, CalendarEventType, CreateEventPayload } from '../../hooks/useCalendarEvents';
+import { ALL_EVENT_TYPES } from '../../components/calendar/CalendarEventDot';
+import CalendarHeader from '../../components/calendar/CalendarHeader';
+import CalendarMonthGrid from '../../components/calendar/CalendarMonthGrid';
+import CalendarListView from '../../components/calendar/CalendarListView';
+import CalendarEventForm from '../../components/calendar/CalendarEventForm';
+import CalendarEventDetail from '../../components/calendar/CalendarEventDetail';
+
+export default function CalendarView() {
+  const nav = useCalendarNavigation();
+  const cal = useCalendarEvents();
+
+  const [selectedCalendarId, setSelectedCalendarId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<CalendarEvent | null>(null);
+  const [defaultDate, setDefaultDate] = useState<Date | null>(null);
+  const [detailEvent, setDetailEvent] = useState<CalendarEvent | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<CalendarEvent | null>(null);
+  const [activeFilters, setActiveFilters] = useState<Set<CalendarEventType>>(
+    () => new Set(ALL_EVENT_TYPES)
+  );
+
+  // On mobile, default to list view
+  useEffect(() => {
+    if (window.innerWidth < 640) {
+      nav.setView('list');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load calendars on mount
+  useEffect(() => {
+    cal.fetchCalendars().then(calendars => {
+      if (calendars.length > 0) {
+        setSelectedCalendarId(calendars[0].id);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fetch events when calendar changes
+  useEffect(() => {
+    if (selectedCalendarId) {
+      cal.fetchEvents(selectedCalendarId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCalendarId]);
+
+  const selectedCalendar = cal.calendars.find(c => c.id === selectedCalendarId);
+
+  // Filter events by active filter types and exclude deleted
+  const filteredEvents = useMemo(() => {
+    return cal.events.filter(
+      e => !e.deleted && activeFilters.has(e.eventType)
+    );
+  }, [cal.events, activeFilters]);
+
+  const handleToggleFilter = useCallback((type: CalendarEventType) => {
+    setActiveFilters(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleDayClick = useCallback((date: Date) => {
+    setDefaultDate(date);
+    setEditingEvent(null);
+    setShowForm(true);
+  }, []);
+
+  const handleEventClick = useCallback((event: CalendarEvent) => {
+    setDetailEvent(event);
+    setShowDetail(true);
+  }, []);
+
+  const handleAddEvent = useCallback(() => {
+    setEditingEvent(null);
+    setDefaultDate(null);
+    setShowForm(true);
+  }, []);
+
+  const handleEditEvent = useCallback((event: CalendarEvent) => {
+    setShowDetail(false);
+    setEditingEvent(event);
+    setShowForm(true);
+  }, []);
+
+  const handleDeleteRequest = useCallback((event: CalendarEvent) => {
+    setShowDetail(false);
+    setDeleteConfirm(event);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteConfirm || !selectedCalendarId) return;
+    try {
+      await cal.deleteEvent(selectedCalendarId, deleteConfirm.id);
+    } catch (err) {
+      console.error('Error al eliminar evento:', err);
+    }
+    setDeleteConfirm(null);
+  }, [deleteConfirm, selectedCalendarId, cal]);
+
+  const handleSaveEvent = useCallback(async (payload: CreateEventPayload) => {
+    if (!selectedCalendarId) return;
+    if (editingEvent) {
+      await cal.updateEvent(selectedCalendarId, editingEvent.id, payload);
+    } else {
+      await cal.createEvent(selectedCalendarId, payload);
+    }
+  }, [selectedCalendarId, editingEvent, cal]);
+
+  // Loading state
+  if (cal.loading && cal.calendars.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 bg-gray-50">
+        <p className="text-gray-500">Cargando calendario...</p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (cal.error && cal.calendars.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 bg-gray-50">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">{cal.error}</p>
+          <button
+            onClick={() => cal.fetchCalendars()}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+          >
+            Reintentar
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (cal.calendars.length === 0 && !cal.loading) {
+    return (
+      <div className="h-full overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6 sm:p-8">
+          <h1 className="text-2xl font-bold text-gray-900 mb-6">Calendario</h1>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-12 text-center">
+            <div className="w-16 h-16 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-4">
+              <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-600"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">No hay calendarios</h3>
+            <p className="text-gray-500 text-sm">
+              Aun no se ha configurado un calendario para esta institucion.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-gray-50">
+      <div className="max-w-6xl mx-auto p-6 sm:p-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Calendario</h1>
+
+        {/* Calendar selector (if multiple) */}
+        {cal.calendars.length > 1 && (
+          <div className="flex gap-2 mb-4">
+            {cal.calendars.map(c => (
+              <button
+                key={c.id}
+                onClick={() => setSelectedCalendarId(c.id)}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  c.id === selectedCalendarId
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white border border-gray-200 text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {c.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Header with filters and legend */}
+        <CalendarHeader
+          currentDate={nav.currentDate}
+          view={nav.view}
+          onPrevMonth={nav.goToPrevMonth}
+          onNextMonth={nav.goToNextMonth}
+          onToday={nav.goToToday}
+          onViewChange={nav.setView}
+          calendarName={selectedCalendar?.name ?? 'Calendario'}
+          onAddEvent={handleAddEvent}
+          activeFilters={activeFilters}
+          onToggleFilter={handleToggleFilter}
+        />
+
+        {/* Loading overlay for events */}
+        {cal.loading && cal.calendars.length > 0 && (
+          <div className="flex justify-center py-8">
+            <p className="text-gray-500 text-sm">Cargando eventos...</p>
+          </div>
+        )}
+
+        {/* Calendar views */}
+        {!cal.loading && nav.view === 'month' && (
+          <CalendarMonthGrid
+            currentDate={nav.currentDate}
+            events={filteredEvents}
+            onDayClick={handleDayClick}
+            onEventClick={handleEventClick}
+          />
+        )}
+
+        {!cal.loading && nav.view === 'list' && (
+          <CalendarListView
+            events={filteredEvents}
+            onEventClick={handleEventClick}
+            onEditEvent={handleEditEvent}
+            onDeleteEvent={handleDeleteRequest}
+          />
+        )}
+      </div>
+
+      {/* Event form modal */}
+      <CalendarEventForm
+        isOpen={showForm}
+        onClose={() => { setShowForm(false); setEditingEvent(null); }}
+        onSave={handleSaveEvent}
+        event={editingEvent}
+        defaultDate={defaultDate}
+      />
+
+      {/* Event detail panel */}
+      <CalendarEventDetail
+        event={detailEvent}
+        isOpen={showDetail}
+        onClose={() => setShowDetail(false)}
+        onEdit={handleEditEvent}
+        onDelete={handleDeleteRequest}
+      />
+
+      {/* Delete confirmation */}
+      {deleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Eliminar evento</h3>
+            <p className="text-sm text-gray-600 mb-6">
+              Estas seguro de que deseas eliminar <strong>{deleteConfirm.name}</strong>? Esta accion no se puede deshacer.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDeleteConfirm(null)}
+                className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleConfirmDelete}
+                className="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700 transition-colors text-sm font-medium"
+              >
+                Eliminar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Academic Sections**: New entity bridging Institution and Group, holding level + accreditation per educational level (UNAM, SEP, IPN, etc.)
- **Calendar Template System**: Immutable global templates copied to editable institution-scoped calendars. V6 seeds SEP Basica, Guarderia, Preescolar, Empresarial. V7 adds MEDIA_SUPERIOR (UNAM DGIRE, SEP DGB, IPN) and INICIAL templates
- **Smart template matching**: Prioritizes by accreditation authority (e.g., UNAM_DGIRE → UNAM template), falls back to generic accredited/non-accredited templates
- **Two-request onboarding architecture**: Splits institution creation (non-tenant-scoped) from setup (tenant-scoped sections + calendars) via `POST /api/onboarding/setup` to properly handle Hibernate `@TenantId` session consistency
- **Tenant-exempt paths**: `/api/me`, `/api/health`, `/api/onboarding/institution` skip tenant validation to prevent 403 with stale `X-Institution-Id`
- **Calendar frontend**: Month grid with colored day cells by event type, list view, event CRUD modal, filter chips, legend, and month navigation using date-fns
- **Functional sidebar navigation**: Dashboard and Settings/Calendar routes with active state

## Test plan
- [ ] Create a new institution with UNAM DGIRE accreditation → verify UNAM calendar is auto-assigned with 20 events
- [ ] Create institution with SEP RVOE on PRIMARIA → verify SEP Basica calendar with 26 events
- [ ] Create institution with no accreditation on MEDIA_SUPERIOR → verify private calendar fallback
- [ ] Navigate to /settings/calendar → verify month grid shows colored days for events
- [ ] Toggle event type filters → verify days update accordingly
- [ ] Click a day with events → verify detail panel opens
- [ ] Add a custom event → verify it appears on the calendar
- [ ] Switch between month and list views
- [ ] Log out, log in with stale localStorage → verify /api/me still works (no 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)