### PR TITLE
feat: Guardian frontend views - students, guardians, modals and routes

### DIFF
--- a/didacta-web/src/App.tsx
+++ b/didacta-web/src/App.tsx
@@ -10,6 +10,9 @@ import CalendarView from './views/settings/CalendarView';
 import StaffListView from './views/staff/StaffListView';
 import StaffProfileView from './views/staff/StaffProfileView';
 import StudentListView from './views/students/StudentListView';
+import StudentProfileView from './views/students/StudentProfileView';
+import GuardianListView from './views/guardians/GuardianListView';
+import GuardianProfileView from './views/guardians/GuardianProfileView';
 
 export default function App() {
   return (
@@ -39,6 +42,24 @@ export default function App() {
           <Route path="/alumnos" element={
             <DashboardLayout>
               <StudentListView />
+            </DashboardLayout>
+          } />
+
+          <Route path="/alumnos/:id" element={
+            <DashboardLayout>
+              <StudentProfileView />
+            </DashboardLayout>
+          } />
+
+          <Route path="/tutores" element={
+            <DashboardLayout>
+              <GuardianListView />
+            </DashboardLayout>
+          } />
+
+          <Route path="/tutores/:id" element={
+            <DashboardLayout>
+              <GuardianProfileView />
             </DashboardLayout>
           } />
 

--- a/didacta-web/src/components/guardians/GuardianEditModal.tsx
+++ b/didacta-web/src/components/guardians/GuardianEditModal.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { updateGuardian } from '../../api/guardianApi';
+import type { GuardianResponse } from '../../types/guardian';
+import InlineError from '../InlineError';
+
+interface GuardianEditModalProps {
+  guardian: GuardianResponse;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function GuardianEditModal({ guardian, isOpen, onClose, onSuccess }: GuardianEditModalProps) {
+  const [firstName, setFirstName] = useState(guardian.firstName);
+  const [lastName, setLastName] = useState(guardian.lastName);
+  const [phone, setPhone] = useState(guardian.phone);
+  const [email, setEmail] = useState(guardian.email || '');
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!firstName.trim()) errors.firstName = 'El nombre es requerido';
+    if (!lastName.trim()) errors.lastName = 'El apellido es requerido';
+    if (!phone.trim()) errors.phone = 'El telefono es requerido';
+    if (email.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      errors.email = 'Correo electronico invalido';
+    }
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateGuardian(guardian.id, {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        phone: phone.trim(),
+        email: email.trim() || undefined,
+      });
+      onSuccess();
+    } catch (err: unknown) {
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        typeof (err as { response?: { status?: number } }).response === 'object' &&
+        (err as { response: { status: number } }).response.status === 409
+      ) {
+        setValidationErrors(prev => ({ ...prev, phone: 'Ya existe un tutor con este telefono' }));
+      } else {
+        setError('No se pudo actualizar el tutor. Intenta de nuevo.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Editar tutor</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <InlineError message={error} />
+
+          {/* Name row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Nombre *</label>
+              <input
+                type="text"
+                value={firstName}
+                onChange={(e) => { setFirstName(e.target.value); setValidationErrors(prev => { const { firstName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.firstName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Maria"
+              />
+              {validationErrors.firstName && <p className="text-xs text-red-500 mt-1">{validationErrors.firstName}</p>}
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Apellido *</label>
+              <input
+                type="text"
+                value={lastName}
+                onChange={(e) => { setLastName(e.target.value); setValidationErrors(prev => { const { lastName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.lastName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Lopez"
+              />
+              {validationErrors.lastName && <p className="text-xs text-red-500 mt-1">{validationErrors.lastName}</p>}
+            </div>
+          </div>
+
+          {/* Contact row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Telefono *</label>
+              <input
+                type="tel"
+                value={phone}
+                onChange={(e) => { setPhone(e.target.value); setValidationErrors(prev => { const { phone: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.phone ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="55 1234 5678"
+              />
+              {validationErrors.phone && <p className="text-xs text-red-500 mt-1">{validationErrors.phone}</p>}
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Correo</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => { setEmail(e.target.value); setValidationErrors(prev => { const { email: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.email ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="correo@ejemplo.com"
+              />
+              {validationErrors.email && <p className="text-xs text-red-500 mt-1">{validationErrors.email}</p>}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm disabled:opacity-50"
+          >
+            {loading ? 'Guardando...' : 'Guardar cambios'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/guardians/LinkStudentToGuardianModal.tsx
+++ b/didacta-web/src/components/guardians/LinkStudentToGuardianModal.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import didactaApi from '../../api/didactaApi';
+import { linkStudentToGuardian } from '../../api/guardianApi';
+import type { Relationship } from '../../types/guardian';
+import { RELATIONSHIP_LABELS } from '../../types/guardian';
+import InlineError from '../InlineError';
+
+interface StudentOption {
+  id: string;
+  firstName: string;
+  lastName: string;
+  groupName: string | null;
+}
+
+interface LinkStudentToGuardianModalProps {
+  guardianId: string;
+  existingStudentIds: string[];
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function LinkStudentToGuardianModal({
+  guardianId,
+  existingStudentIds,
+  isOpen,
+  onClose,
+  onSuccess,
+}: LinkStudentToGuardianModalProps) {
+  const [students, setStudents] = useState<StudentOption[]>([]);
+  const [loadingStudents, setLoadingStudents] = useState(true);
+
+  const [selectedStudentId, setSelectedStudentId] = useState('');
+  const [relationship, setRelationship] = useState<Relationship | ''>('');
+  const [isPrimary, setIsPrimary] = useState(false);
+  const [canPickUp, setCanPickUp] = useState(true);
+  const [receivesNotifications, setReceivesNotifications] = useState(true);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoadingStudents(true);
+    didactaApi
+      .get<StudentOption[]>('/api/onboarding/students')
+      .then((res) => setStudents(res.data.filter((s) => !existingStudentIds.includes(s.id))))
+      .catch(console.error)
+      .finally(() => setLoadingStudents(false));
+  }, [isOpen, existingStudentIds]);
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!selectedStudentId) errors.studentId = 'Selecciona un alumno';
+    if (!relationship) errors.relationship = 'El parentesco es requerido';
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await linkStudentToGuardian(guardianId, {
+        studentId: selectedStudentId,
+        relationship: relationship as string,
+        isPrimary,
+        canPickUp,
+        receivesNotifications,
+      });
+      onSuccess();
+    } catch {
+      setError('No se pudo vincular al alumno. Intenta de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8 max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+          <h2 className="text-lg font-semibold text-gray-900">Vincular hijo</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4 overflow-y-auto flex-1">
+          <InlineError message={error} />
+
+          {/* Student select */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Alumno *</label>
+            {loadingStudents ? (
+              <div className="h-10 bg-gray-100 rounded-lg animate-pulse" />
+            ) : students.length === 0 ? (
+              <p className="text-sm text-gray-500 py-2">
+                Todos los alumnos ya estan vinculados a este tutor.
+              </p>
+            ) : (
+              <select
+                value={selectedStudentId}
+                onChange={(e) => {
+                  setSelectedStudentId(e.target.value);
+                  setValidationErrors((prev) => {
+                    const { studentId: _, ...rest } = prev;
+                    return rest;
+                  });
+                }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.studentId ? 'border-red-300' : 'border-gray-300'}`}
+              >
+                <option value="">Seleccionar alumno</option>
+                {students.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.firstName} {s.lastName}
+                    {s.groupName ? ` - ${s.groupName}` : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+            {validationErrors.studentId && (
+              <p className="text-xs text-red-500 mt-1">{validationErrors.studentId}</p>
+            )}
+          </div>
+
+          {/* Relationship section */}
+          <div className="bg-gray-50 rounded-xl border border-gray-200 p-4 space-y-4">
+            <h4 className="text-sm font-medium text-gray-900">Relacion con el alumno</h4>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Parentesco *</label>
+              <select
+                value={relationship}
+                onChange={(e) => setRelationship(e.target.value as Relationship | '')}
+                className={`w-full border rounded-lg px-4 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.relationship ? 'border-red-300' : 'border-gray-300'}`}
+              >
+                <option value="">Seleccionar parentesco</option>
+                {(Object.entries(RELATIONSHIP_LABELS) as [Relationship, string][]).map(
+                  ([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  )
+                )}
+              </select>
+              {validationErrors.relationship && (
+                <p className="text-xs text-red-500 mt-1">{validationErrors.relationship}</p>
+              )}
+            </div>
+
+            {/* Permission toggles */}
+            <div className="space-y-3">
+              <ToggleField
+                label="Contacto primario"
+                description="Se mostrara como el contacto principal del alumno"
+                checked={isPrimary}
+                onChange={setIsPrimary}
+              />
+              <ToggleField
+                label="Autorizado para recoger"
+                description="Puede recoger al alumno de la institucion"
+                checked={canPickUp}
+                onChange={setCanPickUp}
+              />
+              <ToggleField
+                label="Recibe notificaciones"
+                description="Recibira avisos y comunicados"
+                checked={receivesNotifications}
+                onChange={setReceivesNotifications}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 flex-shrink-0">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading || students.length === 0}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm disabled:opacity-50"
+          >
+            {loading ? 'Guardando...' : 'Vincular'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Toggle subcomponent ---
+
+interface ToggleFieldProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function ToggleField({ label, description, checked, onChange }: ToggleFieldProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm text-gray-900">{label}</p>
+        <p className="text-xs text-gray-500">{description}</p>
+      </div>
+      <label className="relative inline-flex items-center cursor-pointer">
+        <input
+          type="checkbox"
+          className="sr-only peer"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600" />
+      </label>
+    </div>
+  );
+}

--- a/didacta-web/src/views/DashboardLayout.tsx
+++ b/didacta-web/src/views/DashboardLayout.tsx
@@ -51,6 +51,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                         icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg>}
                     />
                     <NavItem
+                        active={isActive('/tutores')}
+                        label="Tutores"
+                        onClick={() => navigate('/tutores')}
+                        icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" /></svg>}
+                    />
+                    <NavItem
                         active={isActive('/equipo')}
                         label="Equipo"
                         onClick={() => navigate('/equipo')}

--- a/didacta-web/src/views/guardians/GuardianListView.tsx
+++ b/didacta-web/src/views/guardians/GuardianListView.tsx
@@ -1,0 +1,307 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listGuardians } from '../../api/guardianApi';
+import type { GuardianListItem } from '../../types/guardian';
+
+export default function GuardianListView() {
+  const navigate = useNavigate();
+
+  const [items, setItems] = useState<GuardianListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(value);
+    }, 300);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const loadGuardians = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    listGuardians({
+      search: debouncedSearch || undefined,
+    })
+      .then(data => setItems(data))
+      .catch(() => setError('No se pudo cargar el directorio de tutores. Intenta de nuevo.'))
+      .finally(() => setLoading(false));
+  }, [debouncedSearch]);
+
+  useEffect(() => {
+    loadGuardians();
+  }, [loadGuardians]);
+
+  const getInitials = (first: string, last: string) =>
+    `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  const renderStudentBadges = (names: string[]) => {
+    const visible = names.slice(0, 3);
+    const remaining = names.length - 3;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {visible.map((name, i) => (
+          <span
+            key={i}
+            className="bg-blue-50 text-blue-700 text-xs px-2 py-0.5 rounded-full font-medium"
+          >
+            {name}
+          </span>
+        ))}
+        {remaining > 0 && (
+          <span className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full font-medium">
+            +{remaining} mas
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full overflow-y-auto bg-gray-50">
+      <div className="max-w-6xl mx-auto p-6 sm:p-8">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Tutores</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Directorio de tutores de la institucion
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
+          <div className="relative">
+            <svg
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <input
+              type="text"
+              placeholder="Buscar por nombre o telefono..."
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+            />
+          </div>
+        </div>
+
+        {/* Counter */}
+        {!loading && !error && (
+          <div className="mb-4">
+            <span className="text-sm text-gray-500">
+              {items.length} {items.length === 1 ? 'tutor' : 'tutores'}
+            </span>
+          </div>
+        )}
+
+        {/* Error state */}
+        {error && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <p className="text-red-600 mb-4 text-sm">{error}</p>
+            <button
+              onClick={loadGuardians}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        {/* Loading skeleton */}
+        {loading && !error && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            {/* Desktop skeleton */}
+            <div className="hidden md:block">
+              <div className="bg-gray-50 px-6 py-3 border-b border-gray-200">
+                <div className="flex gap-8">
+                  <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-3 w-40 bg-gray-200 rounded animate-pulse" />
+                </div>
+              </div>
+              {[1, 2, 3, 4, 5].map(i => (
+                <div key={i} className="px-6 py-4 border-b border-gray-100 flex gap-8 items-center">
+                  <div className="flex items-center gap-3 w-56">
+                    <div className="w-9 h-9 rounded-full bg-gray-200 animate-pulse" />
+                    <div className="space-y-1.5">
+                      <div className="h-3 w-28 bg-gray-200 rounded animate-pulse" />
+                      <div className="h-2.5 w-36 bg-gray-100 rounded animate-pulse" />
+                    </div>
+                  </div>
+                  <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+                  <div className="flex gap-1">
+                    <div className="h-5 w-20 bg-gray-200 rounded-full animate-pulse" />
+                    <div className="h-5 w-16 bg-gray-200 rounded-full animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+            {/* Mobile skeleton */}
+            <div className="md:hidden space-y-3 p-4">
+              {[1, 2, 3].map(i => (
+                <div key={i} className="bg-white rounded-xl border border-gray-100 p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full bg-gray-200 animate-pulse" />
+                    <div className="space-y-1.5 flex-1">
+                      <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
+                      <div className="h-2.5 w-24 bg-gray-100 rounded animate-pulse" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && items.length === 0 && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <div className="w-16 h-16 rounded-full bg-pink-50 flex items-center justify-center mx-auto mb-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-pink-600"
+              >
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+            {debouncedSearch ? (
+              <>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">Sin resultados</h3>
+                <p className="text-gray-500 text-sm">
+                  No se encontraron tutores con esa busqueda.
+                </p>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  Aun no hay tutores registrados
+                </h3>
+                <p className="text-gray-500 text-sm mb-4">
+                  Los tutores se agregan desde el perfil de cada alumno.
+                </p>
+                <button
+                  onClick={() => navigate('/alumnos')}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm"
+                >
+                  Ir a alumnos
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Data */}
+        {!loading && !error && items.length > 0 && (
+          <>
+            {/* Desktop table */}
+            <div className="hidden md:block bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-gray-50 text-gray-500 font-medium border-b border-gray-200">
+                  <tr>
+                    <th className="px-6 py-3">NOMBRE</th>
+                    <th className="px-6 py-3">TELEFONO</th>
+                    <th className="px-6 py-3">HIJOS</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {items.map(guardian => (
+                    <tr
+                      key={guardian.id}
+                      onClick={() => navigate(`/tutores/${guardian.id}`)}
+                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-3">
+                          <div className="w-9 h-9 rounded-full bg-pink-100 text-pink-600 flex items-center justify-center font-bold text-xs flex-shrink-0">
+                            {getInitials(guardian.firstName, guardian.lastName)}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="font-medium text-gray-900 truncate">
+                              {guardian.firstName} {guardian.lastName}
+                            </div>
+                            {guardian.email && (
+                              <div className="text-xs text-gray-500 truncate">
+                                {guardian.email}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-gray-600">{guardian.phone}</td>
+                      <td className="px-6 py-4">
+                        {guardian.studentNames.length > 0
+                          ? renderStudentBadges(guardian.studentNames)
+                          : <span className="text-gray-400 text-xs">Sin hijos vinculados</span>
+                        }
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile cards */}
+            <div className="md:hidden space-y-3">
+              {items.map(guardian => (
+                <div
+                  key={guardian.id}
+                  onClick={() => navigate(`/tutores/${guardian.id}`)}
+                  className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 cursor-pointer hover:shadow-md transition-shadow"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 rounded-full bg-pink-100 text-pink-600 flex items-center justify-center font-bold text-xs flex-shrink-0">
+                      {getInitials(guardian.firstName, guardian.lastName)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-gray-900 truncate">
+                        {guardian.firstName} {guardian.lastName}
+                      </div>
+                      {guardian.email && (
+                        <p className="text-xs text-gray-500 mt-0.5 truncate">{guardian.email}</p>
+                      )}
+                      <p className="text-xs text-gray-500 mt-1">{guardian.phone}</p>
+                      {guardian.studentNames.length > 0 && (
+                        <div className="mt-2">
+                          {renderStudentBadges(guardian.studentNames)}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/views/guardians/GuardianProfileView.tsx
+++ b/didacta-web/src/views/guardians/GuardianProfileView.tsx
@@ -1,0 +1,345 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getGuardian, unlinkStudent } from '../../api/guardianApi';
+import type { GuardianResponse, StudentLinkResponse, Relationship } from '../../types/guardian';
+import { RELATIONSHIP_LABELS, RELATIONSHIP_COLORS } from '../../types/guardian';
+import GuardianEditModal from '../../components/guardians/GuardianEditModal';
+import LinkStudentToGuardianModal from '../../components/guardians/LinkStudentToGuardianModal';
+import ConfirmDialog from '../../components/staff/ConfirmDialog';
+
+export default function GuardianProfileView() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [guardian, setGuardian] = useState<GuardianResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [showLinkModal, setShowLinkModal] = useState(false);
+  const [unlinkTarget, setUnlinkTarget] = useState<StudentLinkResponse | null>(null);
+  const [unlinkLoading, setUnlinkLoading] = useState(false);
+
+  const loadGuardian = () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    getGuardian(id)
+      .then(setGuardian)
+      .catch(() => setError('No se pudo cargar el perfil del tutor. Intenta de nuevo.'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadGuardian();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const handleUnlink = async () => {
+    if (!unlinkTarget || !id) return;
+    setUnlinkLoading(true);
+    try {
+      await unlinkStudent(id, unlinkTarget.linkId);
+      setGuardian((prev) =>
+        prev
+          ? { ...prev, students: prev.students.filter((s) => s.linkId !== unlinkTarget.linkId) }
+          : prev
+      );
+      setUnlinkTarget(null);
+    } catch {
+      setError('No se pudo desvincular al alumno.');
+    } finally {
+      setUnlinkLoading(false);
+    }
+  };
+
+  const getInitials = (first: string, last: string) =>
+    `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  const getRelationshipBadge = (rel: string) => {
+    const label = RELATIONSHIP_LABELS[rel as Relationship] || rel;
+    const colors = RELATIONSHIP_COLORS[rel as Relationship] || 'bg-gray-100 text-gray-700';
+    return (
+      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors}`}>
+        {label}
+      </span>
+    );
+  };
+
+  // Loading
+  if (loading) {
+    return (
+      <div className="h-full overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6 sm:p-8">
+          <div className="h-4 w-32 bg-gray-200 rounded animate-pulse mb-6" />
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-full bg-gray-200 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-5 w-40 bg-gray-200 rounded animate-pulse" />
+                <div className="h-3 w-28 bg-gray-100 rounded animate-pulse" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error
+  if (error && !guardian) {
+    return (
+      <div className="h-full overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6 sm:p-8">
+          <button
+            onClick={() => navigate('/tutores')}
+            className="text-sm text-gray-500 hover:text-gray-700 mb-6 flex items-center gap-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+            Volver a tutores
+          </button>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <p className="text-red-600 mb-4 text-sm">{error}</p>
+            <button
+              onClick={loadGuardian}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!guardian) return null;
+
+  return (
+    <div className="h-full overflow-y-auto bg-gray-50">
+      <div className="max-w-4xl mx-auto p-6 sm:p-8">
+        {/* Back button */}
+        <button
+          onClick={() => navigate('/tutores')}
+          className="text-sm text-gray-500 hover:text-gray-700 mb-6 flex items-center gap-1"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+          Volver a tutores
+        </button>
+
+        {/* Error banner (for action errors) */}
+        {error && (
+          <div className="mb-4 p-3 rounded-lg text-sm font-medium bg-red-50 text-red-700 border border-red-200">
+            {error}
+          </div>
+        )}
+
+        {/* Header card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+          <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+            {/* Avatar */}
+            <div className="w-16 h-16 rounded-full bg-pink-100 text-pink-600 flex items-center justify-center font-bold text-xl flex-shrink-0">
+              {getInitials(guardian.firstName, guardian.lastName)}
+            </div>
+
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <h1 className="text-xl font-bold text-gray-900">
+                {guardian.firstName} {guardian.lastName}
+              </h1>
+              <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 mt-1">
+                {guardian.phone && (
+                  <span className="text-sm text-gray-600 flex items-center gap-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" /></svg>
+                    {guardian.phone}
+                  </span>
+                )}
+                {guardian.email && (
+                  <span className="text-sm text-gray-600 flex items-center gap-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" /><polyline points="22,6 12,13 2,6" /></svg>
+                    {guardian.email}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                onClick={() => setShowEditModal(true)}
+                className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
+              >
+                Editar
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Contact info */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h2 className="text-sm font-semibold text-gray-900 mb-4 uppercase tracking-wide">
+              Informacion de contacto
+            </h2>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" /></svg>
+                <span className="text-sm text-gray-700">{guardian.phone}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" /><polyline points="22,6 12,13 2,6" /></svg>
+                <span className={`text-sm ${guardian.email ? 'text-gray-700' : 'text-gray-400'}`}>
+                  {guardian.email || 'No registrado'}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+                <span className="text-sm text-gray-500">
+                  Registrado el{' '}
+                  {new Date(guardian.createdAt).toLocaleDateString('es-MX', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Status card */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h2 className="text-sm font-semibold text-gray-900 mb-4 uppercase tracking-wide">
+              Detalles
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-500">Estado</span>
+                <span
+                  className={`text-sm font-medium ${guardian.status === 'ACTIVE' ? 'text-green-700' : 'text-red-600'}`}
+                >
+                  {guardian.status === 'ACTIVE' ? 'Activo' : 'Inactivo'}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-500">Hijos vinculados</span>
+                <span className="text-sm font-medium text-gray-900">{guardian.students.length}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Linked students card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mt-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+              Hijos vinculados
+            </h2>
+            <button
+              onClick={() => setShowLinkModal(true)}
+              className="bg-blue-600 text-white px-3 py-1.5 rounded-lg font-medium hover:bg-blue-700 transition-colors text-xs flex items-center gap-1"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
+              Vincular hijo
+            </button>
+          </div>
+
+          {guardian.students.length === 0 ? (
+            <div className="text-center py-8">
+              <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /></svg>
+              </div>
+              <p className="text-sm text-gray-500">No tiene hijos vinculados</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {guardian.students.map((student) => (
+                <div
+                  key={student.linkId}
+                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link
+                        to={`/alumnos/${student.studentId}`}
+                        className="text-sm font-medium text-blue-600 hover:underline"
+                      >
+                        {student.studentFirstName} {student.studentLastName}
+                      </Link>
+                      {getRelationshipBadge(student.relationship)}
+                    </div>
+                    {student.groupName && (
+                      <p className="text-xs text-gray-500 mt-0.5">{student.groupName}</p>
+                    )}
+                    <div className="flex flex-wrap gap-1.5 mt-1.5">
+                      {student.isPrimary && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-700 border border-yellow-200">
+                          Primario
+                        </span>
+                      )}
+                      {student.canPickUp && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-50 text-green-700 border border-green-200">
+                          Puede recoger
+                        </span>
+                      )}
+                      {student.receivesNotifications && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200">
+                          Notificaciones
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => setUnlinkTarget(student)}
+                    className="text-gray-400 hover:text-red-500 p-1 transition-colors flex-shrink-0 ml-2"
+                    title="Desvincular"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Edit Modal */}
+      {showEditModal && (
+        <GuardianEditModal
+          guardian={guardian}
+          isOpen={showEditModal}
+          onClose={() => setShowEditModal(false)}
+          onSuccess={() => {
+            setShowEditModal(false);
+            loadGuardian();
+          }}
+        />
+      )}
+
+      {/* Link Student Modal */}
+      <LinkStudentToGuardianModal
+        guardianId={guardian.id}
+        existingStudentIds={guardian.students.map((s) => s.studentId)}
+        isOpen={showLinkModal}
+        onClose={() => setShowLinkModal(false)}
+        onSuccess={() => {
+          setShowLinkModal(false);
+          loadGuardian();
+        }}
+      />
+
+      {/* Unlink confirm dialog */}
+      <ConfirmDialog
+        isOpen={!!unlinkTarget}
+        title="Desvincular alumno"
+        description={
+          unlinkTarget
+            ? `Se desvinculara a ${unlinkTarget.studentFirstName} ${unlinkTarget.studentLastName} de este tutor. Esta accion no se puede deshacer.`
+            : ''
+        }
+        confirmLabel="Desvincular"
+        loading={unlinkLoading}
+        onConfirm={handleUnlink}
+        onCancel={() => setUnlinkTarget(null)}
+      />
+    </div>
+  );
+}

--- a/didacta-web/src/views/students/StudentListView.tsx
+++ b/didacta-web/src/views/students/StudentListView.tsx
@@ -1,0 +1,330 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import didactaApi from '../../api/didactaApi';
+
+interface StudentItem {
+  id: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+  groupId: string | null;
+  groupName: string | null;
+}
+
+interface GroupOption {
+  id: string;
+  name: string;
+  gradeLevel: string;
+}
+
+export default function StudentListView() {
+  const navigate = useNavigate();
+
+  const [students, setStudents] = useState<StudentItem[]>([]);
+  const [groups, setGroups] = useState<GroupOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [groupFilter, setGroupFilter] = useState('');
+
+  const loadData = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      didactaApi.get<StudentItem[]>('/api/onboarding/students'),
+      didactaApi.get<GroupOption[]>('/api/onboarding/groups'),
+    ])
+      .then(([studentsRes, groupsRes]) => {
+        setStudents(studentsRes.data);
+        setGroups(groupsRes.data);
+      })
+      .catch(() => setError('No se pudo cargar los alumnos. Intenta de nuevo.'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const filtered = useMemo(() => {
+    let result = students;
+    if (search) {
+      const term = search.toLowerCase();
+      result = result.filter(
+        (s) =>
+          s.firstName.toLowerCase().includes(term) ||
+          s.lastName.toLowerCase().includes(term) ||
+          `${s.firstName} ${s.lastName}`.toLowerCase().includes(term)
+      );
+    }
+    if (groupFilter) {
+      result = result.filter((s) => s.groupId === groupFilter);
+    }
+    return result;
+  }, [students, search, groupFilter]);
+
+  const hasFilters = search || groupFilter;
+
+  const getInitials = (first: string, last: string) =>
+    `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  return (
+    <div className="h-full overflow-y-auto bg-gray-50">
+      <div className="max-w-6xl mx-auto p-6 sm:p-8">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Alumnos</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Gestiona los alumnos de tu institucion
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
+          <div className="flex flex-col sm:flex-row gap-3">
+            {/* Search */}
+            <div className="relative flex-1">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+              <input
+                type="text"
+                placeholder="Buscar por nombre..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+              />
+            </div>
+
+            {/* Group filter */}
+            {groups.length > 0 && (
+              <select
+                value={groupFilter}
+                onChange={(e) => setGroupFilter(e.target.value)}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none"
+              >
+                <option value="">Todos los grupos</option>
+                {groups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </div>
+
+        {/* Counter */}
+        <div className="mb-4">
+          <span className="text-sm text-gray-500">
+            {hasFilters
+              ? `${filtered.length} resultados`
+              : `${students.length} alumnos`}
+          </span>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <p className="text-red-600 mb-4 text-sm">{error}</p>
+            <button
+              onClick={loadData}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        {/* Loading skeleton */}
+        {loading && !error && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+            {/* Desktop skeleton */}
+            <div className="hidden md:block">
+              <div className="bg-gray-50 px-6 py-3 border-b border-gray-200">
+                <div className="flex gap-8">
+                  <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-3 w-20 bg-gray-200 rounded animate-pulse" />
+                </div>
+              </div>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div
+                  key={i}
+                  className="px-6 py-4 border-b border-gray-100 flex gap-8 items-center"
+                >
+                  <div className="flex items-center gap-3 w-48">
+                    <div className="w-9 h-9 rounded-full bg-gray-200 animate-pulse" />
+                    <div className="space-y-1.5">
+                      <div className="h-3 w-28 bg-gray-200 rounded animate-pulse" />
+                      <div className="h-2.5 w-20 bg-gray-100 rounded animate-pulse" />
+                    </div>
+                  </div>
+                  <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-5 w-16 bg-gray-200 rounded-full animate-pulse" />
+                </div>
+              ))}
+            </div>
+            {/* Mobile skeleton */}
+            <div className="md:hidden space-y-3 p-4">
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="bg-white rounded-xl border border-gray-100 p-4"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full bg-gray-200 animate-pulse" />
+                    <div className="space-y-1.5 flex-1">
+                      <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
+                      <div className="h-2.5 w-24 bg-gray-100 rounded animate-pulse" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && filtered.length === 0 && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <div className="w-16 h-16 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-4">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-blue-600"
+              >
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+              </svg>
+            </div>
+            {hasFilters ? (
+              <>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  Sin resultados
+                </h3>
+                <p className="text-gray-500 text-sm">
+                  No se encontraron alumnos con los filtros seleccionados.
+                </p>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  Aun no hay alumnos
+                </h3>
+                <p className="text-gray-500 text-sm">
+                  Los alumnos se agregan durante el proceso de onboarding.
+                </p>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Data */}
+        {!loading && !error && filtered.length > 0 && (
+          <>
+            {/* Desktop table */}
+            <div className="hidden md:block bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-gray-50 text-gray-500 font-medium border-b border-gray-200">
+                  <tr>
+                    <th className="px-6 py-3">NOMBRE</th>
+                    <th className="px-6 py-3">GRUPO</th>
+                    <th className="px-6 py-3">TUTORES</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {filtered.map((student) => (
+                    <tr
+                      key={student.id}
+                      onClick={() => navigate(`/alumnos/${student.id}`)}
+                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-3">
+                          <div className="w-9 h-9 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-bold text-xs flex-shrink-0">
+                            {getInitials(student.firstName, student.lastName)}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="font-medium text-gray-900 truncate">
+                              {student.firstName} {student.lastName}
+                            </div>
+                            {student.groupName && (
+                              <div className="text-xs text-gray-500 truncate">
+                                {student.groupName}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-gray-600">
+                        {student.groupName || '-'}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
+                          --
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Mobile cards */}
+            <div className="md:hidden space-y-3">
+              {filtered.map((student) => (
+                <div
+                  key={student.id}
+                  onClick={() => navigate(`/alumnos/${student.id}`)}
+                  className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 cursor-pointer hover:shadow-md transition-shadow"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-bold text-xs flex-shrink-0">
+                      {getInitials(student.firstName, student.lastName)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium text-gray-900 truncate">
+                          {student.firstName} {student.lastName}
+                        </span>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 flex-shrink-0">
+                          --
+                        </span>
+                      </div>
+                      {student.groupName && (
+                        <p className="text-xs text-gray-500 mt-0.5">
+                          {student.groupName}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/views/students/StudentProfileView.tsx
+++ b/didacta-web/src/views/students/StudentProfileView.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import didactaApi from '../../api/didactaApi';
+import { getGuardiansOfStudent, unlinkStudent } from '../../api/guardianApi';
+import GuardianLinkModal from '../../components/guardians/GuardianLinkModal';
+import type { GuardianOfStudentResponse, Relationship } from '../../types/guardian';
+import { RELATIONSHIP_LABELS, RELATIONSHIP_COLORS } from '../../types/guardian';
+
+interface StudentDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+  groupId: string | null;
+  groupName: string | null;
+}
+
+interface GroupOption {
+  id: string;
+  name: string;
+  gradeLevel: string;
+}
+
+export default function StudentProfileView() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [student, setStudent] = useState<StudentDto | null>(null);
+  const [gradeLevel, setGradeLevel] = useState<string | null>(null);
+  const [guardians, setGuardians] = useState<GuardianOfStudentResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showLinkModal, setShowLinkModal] = useState(false);
+
+  const getInitials = (first: string, last: string) =>
+    `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  const loadGuardians = useCallback(() => {
+    if (!id) return;
+    getGuardiansOfStudent(id)
+      .then(setGuardians)
+      .catch(console.error);
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      didactaApi.get<StudentDto[]>('/api/onboarding/students'),
+      didactaApi.get<GroupOption[]>('/api/onboarding/groups'),
+      getGuardiansOfStudent(id),
+    ])
+      .then(([studentsRes, groupsRes, guardiansRes]) => {
+        const found = studentsRes.data.find(s => s.id === id);
+        if (!found) {
+          setError('No se encontro el alumno.');
+          return;
+        }
+        setStudent(found);
+        setGuardians(guardiansRes);
+
+        if (found.groupId) {
+          const group = groupsRes.data.find(g => g.id === found.groupId);
+          if (group) setGradeLevel(group.gradeLevel);
+        }
+      })
+      .catch(() => setError('No se pudo cargar el perfil. Intenta de nuevo.'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  const handleUnlink = async (guardian: GuardianOfStudentResponse) => {
+    const confirmed = window.confirm(
+      `Se desvinculara a ${guardian.firstName} ${guardian.lastName} de este alumno. Esta accion no se puede deshacer.`
+    );
+    if (!confirmed) return;
+
+    try {
+      await unlinkStudent(guardian.guardianId, guardian.linkId);
+      setGuardians(prev => prev.filter(g => g.linkId !== guardian.linkId));
+    } catch {
+      alert('No se pudo desvincular al tutor. Intenta de nuevo.');
+    }
+  };
+
+  const handleLinkSuccess = () => {
+    setShowLinkModal(false);
+    loadGuardians();
+  };
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div className="h-full overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6 sm:p-8">
+          <div className="h-4 w-32 bg-gray-200 rounded animate-pulse mb-6" />
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 rounded-full bg-gray-200 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-5 w-40 bg-gray-200 rounded animate-pulse" />
+                <div className="h-3 w-28 bg-gray-100 rounded animate-pulse" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error
+  if (error || !student) {
+    return (
+      <div className="h-full overflow-y-auto bg-gray-50">
+        <div className="max-w-4xl mx-auto p-6 sm:p-8">
+          <button
+            onClick={() => navigate('/alumnos')}
+            className="text-sm text-gray-500 hover:text-gray-700 mb-6 flex items-center gap-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+            Volver a alumnos
+          </button>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
+            <p className="text-red-600 mb-4 text-sm">{error || 'No se encontro el alumno.'}</p>
+            <button
+              onClick={() => navigate(0)}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-gray-50">
+      <div className="max-w-4xl mx-auto p-6 sm:p-8">
+        {/* Back button */}
+        <button
+          onClick={() => navigate('/alumnos')}
+          className="text-sm text-gray-500 hover:text-gray-700 mb-6 flex items-center gap-1"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+          Volver a alumnos
+        </button>
+
+        {/* Header card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+          <div className="flex items-center gap-4">
+            <div className="w-16 h-16 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-bold text-xl flex-shrink-0">
+              {getInitials(student.firstName, student.lastName)}
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-xl font-bold text-gray-900">
+                {student.firstName} {student.lastName}
+              </h1>
+              {(student.groupName || gradeLevel) && (
+                <p className="text-sm text-gray-500">
+                  {[student.groupName, gradeLevel].filter(Boolean).join(' - ')}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Guardians card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+              Tutores vinculados
+            </h2>
+            <button
+              onClick={() => setShowLinkModal(true)}
+              className="bg-blue-600 text-white px-3 py-1.5 rounded-lg font-medium hover:bg-blue-700 transition-colors text-xs flex items-center gap-1"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
+              Agregar tutor
+            </button>
+          </div>
+
+          {guardians.length === 0 ? (
+            <div className="text-center py-8">
+              <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>
+              </div>
+              <p className="text-sm text-gray-500">No tiene tutores vinculados</p>
+              <p className="text-xs text-gray-400 mt-1">Agrega un tutor para registrar datos de contacto y permisos</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {guardians.map(guardian => (
+                <div
+                  key={guardian.linkId}
+                  className="flex flex-col sm:flex-row sm:items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-100 gap-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    {/* Name + relationship badge */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-gray-900">
+                        {guardian.firstName} {guardian.lastName}
+                      </span>
+                      <span className={`${RELATIONSHIP_COLORS[guardian.relationship as Relationship] || 'bg-gray-100 text-gray-700'} text-xs font-medium px-2 py-0.5 rounded-full`}>
+                        {RELATIONSHIP_LABELS[guardian.relationship as Relationship] || guardian.relationship}
+                      </span>
+                    </div>
+
+                    {/* Contact info */}
+                    <div className="flex items-center gap-3 mt-1 flex-wrap">
+                      {guardian.phone && (
+                        <span className="text-xs text-gray-500">{guardian.phone}</span>
+                      )}
+                      {guardian.email && (
+                        <span className="text-xs text-gray-500">{guardian.email}</span>
+                      )}
+                    </div>
+
+                    {/* Permission badges */}
+                    <div className="flex items-center gap-2 mt-2 flex-wrap">
+                      {guardian.isPrimary && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-green-50 text-green-700 border border-green-200">
+                          Contacto primario
+                        </span>
+                      )}
+                      {guardian.canPickUp && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+                          Aut. recoger
+                        </span>
+                      )}
+                      {guardian.receivesNotifications && (
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-200">
+                          Recibe notif.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Delete button */}
+                  <button
+                    onClick={() => handleUnlink(guardian)}
+                    className="text-gray-400 hover:text-red-500 p-1 transition-colors flex-shrink-0 self-start sm:self-center"
+                    title="Desvincular tutor"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Guardian Link Modal */}
+      {id && (
+        <GuardianLinkModal
+          studentId={id}
+          isOpen={showLinkModal}
+          onClose={() => setShowLinkModal(false)}
+          onSuccess={handleLinkSuccess}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Student list and profile views with guardian linking
- Guardian directory and profile views with edit/link modals
- Sidebar and routes for /alumnos and /tutores

## Frontend (8 files)
### Student Views
- `StudentListView` (/alumnos): search + group filter + table/cards + navigation
- `StudentProfileView` (/alumnos/:id): student data + guardians section with link/unlink

### Guardian Views
- `GuardianListView` (/tutores): directory with search, children as badges
- `GuardianProfileView` (/tutores/:id): contact info + linked children + edit

### Modals
- `GuardianLinkModal`: search existing by phone + create new guardian flow
- `GuardianEditModal`: edit with phone 409 error handling
- `LinkStudentToGuardianModal`: link child from guardian profile

### Navigation
- Routes: /alumnos, /alumnos/:id, /tutores, /tutores/:id
- Sidebar: Alumnos and Tutores nav items with icons

## Test plan
- [ ] `cd didacta-web && npx tsc --noEmit` passes
- [ ] /alumnos lists students with search and group filter
- [ ] /alumnos/:id shows student profile with guardians section
- [ ] GuardianLinkModal: search finds existing guardian by phone
- [ ] GuardianLinkModal: creates new guardian + links to student
- [ ] /tutores lists guardians with children badges
- [ ] /tutores/:id shows guardian with linked children
- [ ] Edit modal handles phone 409 error

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)