### PR TITLE
fix: resolve lower(bytea) SQL error in guardian and staff search

### DIFF
--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaGuardianRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaGuardianRepository.java
@@ -23,7 +23,11 @@ public interface JpaGuardianRepository extends JpaRepository<Guardian, UUID> {
 
     @Query("SELECT g FROM Guardian g WHERE g.institutionId = :instId " +
            "AND (:status IS NULL OR g.status = :status) " +
-           "AND (:search IS NULL OR LOWER(CONCAT(g.firstName, ' ', g.lastName, ' ', COALESCE(g.phone, ''), ' ', COALESCE(g.email, ''))) LIKE LOWER(CONCAT('%', :search, '%')))")
+           "AND (CAST(:search AS STRING) IS NULL " +
+           "OR LOWER(g.firstName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR LOWER(g.lastName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR LOWER(g.phone) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR (g.email IS NOT NULL AND LOWER(g.email) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%'))))")
     List<Guardian> findByFilters(@Param("instId") UUID institutionId,
                                  @Param("status") String status,
                                  @Param("search") String search);

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStaffMemberRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStaffMemberRepository.java
@@ -22,7 +22,10 @@ public interface JpaStaffMemberRepository extends JpaRepository<StaffMember, UUI
            "AND (:campusId IS NULL OR s.campusId = :campusId) " +
            "AND (:category IS NULL OR s.category = :category) " +
            "AND (:status IS NULL OR s.status = :status) " +
-           "AND (:search IS NULL OR LOWER(CONCAT(s.firstName, ' ', s.lastName, ' ', COALESCE(s.email, ''))) LIKE LOWER(CONCAT('%', :search, '%')))")
+           "AND (CAST(:search AS STRING) IS NULL " +
+           "OR LOWER(s.firstName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR LOWER(s.lastName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR (s.email IS NOT NULL AND LOWER(s.email) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%'))))")
     List<StaffMember> findByFilters(@Param("instId") UUID institutionId,
                                      @Param("campusId") UUID campusId,
                                      @Param("category") String category,


### PR DESCRIPTION
## Summary
- Fixed `lower(bytea) does not exist` PostgreSQL error when searching guardians and staff
- Split CONCAT-based search into separate LIKE conditions per field
- Applied fix to both JpaGuardianRepository and JpaStaffMemberRepository

## Root cause
PostgreSQL infers `bytea` type for untyped null bind parameters inside `CONCAT()`. When `LOWER()` is called on the result, it fails.

## Test plan
- [ ] Navigate to /tutores → list loads without error
- [ ] Search by name works
- [ ] Search by phone works
- [ ] Navigate to /equipo → list loads without error
- [ ] Staff search works

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)