### PR TITLE
feat: Students CRUD module

### DIFF
--- a/didacta-api/src/main/java/com/didacta/api/application/dto/StudentCommand.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/StudentCommand.java
@@ -1,0 +1,37 @@
+package com.didacta.api.application.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class StudentCommand {
+
+    @Data
+    public static class Create {
+        @NotBlank private String firstName;
+        @NotBlank private String lastName;
+        @NotNull private UUID groupId;
+        private LocalDate dateOfBirth;
+    }
+
+    @Data
+    public static class Update {
+        @NotBlank private String firstName;
+        @NotBlank private String lastName;
+        private LocalDate dateOfBirth;
+    }
+
+    @Data
+    public static class ChangeGroup {
+        @NotNull private UUID groupId;
+    }
+
+    @Data
+    public static class ChangeStatus {
+        @NotBlank
+        @Pattern(regexp = "ACTIVE|INACTIVE")
+        private String status;
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/dto/StudentResult.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/dto/StudentResult.java
@@ -1,0 +1,34 @@
+package com.didacta.api.application.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class StudentResult {
+
+    @Data @Builder
+    public static class StudentResponse {
+        private UUID id;
+        private String firstName;
+        private String lastName;
+        private LocalDate dateOfBirth;
+        private String status;
+        private UUID groupId;
+        private String groupName;
+        private LocalDate enrollmentDate;
+        private String createdAt;
+    }
+
+    @Data @Builder
+    public static class StudentListItem {
+        private UUID id;
+        private String firstName;
+        private String lastName;
+        private String status;
+        private UUID groupId;
+        private String groupName;
+        private int guardianCount;
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/application/mapper/StudentMapper.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/mapper/StudentMapper.java
@@ -1,6 +1,7 @@
 package com.didacta.api.application.mapper;
 
 import com.didacta.api.application.dto.OnboardingResult;
+import com.didacta.api.application.dto.StudentResult;
 import com.didacta.api.domain.model.Student;
 
 public class StudentMapper {
@@ -25,6 +26,32 @@ public class StudentMapper {
                 .status(student.getStatus())
                 .groupId(student.getGroupId())
                 .groupName(groupName)
+                .build();
+    }
+
+    public static StudentResult.StudentResponse toStudentResponse(Student student, String groupName) {
+        return StudentResult.StudentResponse.builder()
+                .id(student.getId())
+                .firstName(student.getFirstName())
+                .lastName(student.getLastName())
+                .dateOfBirth(student.getDateOfBirth())
+                .status(student.getStatus())
+                .groupId(student.getGroupId())
+                .groupName(groupName)
+                .enrollmentDate(student.getEnrollmentDate())
+                .createdAt(student.getCreatedAt() != null ? student.getCreatedAt().toString() : null)
+                .build();
+    }
+
+    public static StudentResult.StudentListItem toStudentListItem(Student student, String groupName, int guardianCount) {
+        return StudentResult.StudentListItem.builder()
+                .id(student.getId())
+                .firstName(student.getFirstName())
+                .lastName(student.getLastName())
+                .status(student.getStatus())
+                .groupId(student.getGroupId())
+                .groupName(groupName)
+                .guardianCount(guardianCount)
                 .build();
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageStudentsUseCase.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/input/ManageStudentsUseCase.java
@@ -2,10 +2,23 @@ package com.didacta.api.application.port.input;
 
 import com.didacta.api.application.dto.OnboardingCommand;
 import com.didacta.api.application.dto.OnboardingResult;
+import com.didacta.api.application.dto.StudentCommand;
+import com.didacta.api.application.dto.StudentResult;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface ManageStudentsUseCase {
+
+    // Onboarding (existing)
     OnboardingResult.StudentsCreated create(String keycloakUserId, OnboardingCommand.CreateStudents command);
     List<OnboardingResult.StudentDto> listByInstitution();
+
+    // CRUD
+    StudentResult.StudentResponse createStudent(StudentCommand.Create command);
+    StudentResult.StudentResponse getById(UUID id);
+    List<StudentResult.StudentListItem> list(String status, String search, UUID groupId);
+    StudentResult.StudentResponse update(UUID id, StudentCommand.Update command);
+    void changeGroup(UUID id, StudentCommand.ChangeGroup command);
+    void changeStatus(UUID id, StudentCommand.ChangeStatus command);
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/StudentGuardianRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/StudentGuardianRepositoryPort.java
@@ -3,6 +3,7 @@ package com.didacta.api.application.port.output;
 import com.didacta.api.domain.model.StudentGuardian;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,5 +13,7 @@ public interface StudentGuardianRepositoryPort {
     List<StudentGuardian> findByStudentId(UUID studentId);
     List<StudentGuardian> findByGuardianId(UUID guardianId);
     boolean existsByStudentIdAndGuardianId(UUID studentId, UUID guardianId);
+    long countByStudentId(UUID studentId);
+    Map<UUID, Long> countByStudentIds(List<UUID> studentIds);
     void deleteById(UUID id);
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/port/output/StudentRepositoryPort.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/port/output/StudentRepositoryPort.java
@@ -11,5 +11,8 @@ public interface StudentRepositoryPort {
     List<Student> findByInstitutionId(UUID institutionId);
     Optional<Student> findById(UUID id);
     boolean existsByIdAndInstitutionId(UUID id, UUID institutionId);
+    List<Student> findByInstitutionIdAndFilters(UUID institutionId, String status, String search, UUID groupId);
+    long countByInstitutionId(UUID institutionId);
+    void deleteById(UUID id);
     Student save(Student student);
 }

--- a/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageStudentsService.java
+++ b/didacta-api/src/main/java/com/didacta/api/application/usecase/ManageStudentsService.java
@@ -2,9 +2,12 @@ package com.didacta.api.application.usecase;
 
 import com.didacta.api.application.dto.OnboardingCommand;
 import com.didacta.api.application.dto.OnboardingResult;
+import com.didacta.api.application.dto.StudentCommand;
+import com.didacta.api.application.dto.StudentResult;
 import com.didacta.api.application.mapper.StudentMapper;
 import com.didacta.api.application.port.input.ManageStudentsUseCase;
 import com.didacta.api.application.port.output.GroupRepositoryPort;
+import com.didacta.api.application.port.output.StudentGuardianRepositoryPort;
 import com.didacta.api.application.port.output.StudentRepositoryPort;
 import com.didacta.api.application.port.output.TenantProviderPort;
 import com.didacta.api.domain.exception.EntityNotFoundException;
@@ -16,8 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -27,7 +33,10 @@ public class ManageStudentsService implements ManageStudentsUseCase {
 
     private final StudentRepositoryPort studentRepository;
     private final GroupRepositoryPort groupRepository;
+    private final StudentGuardianRepositoryPort studentGuardianRepository;
     private final TenantProviderPort tenantProvider;
+
+    // ── Onboarding (existing) ───────────────────────────────────────────
 
     @Override
     @Transactional
@@ -67,7 +76,6 @@ public class ManageStudentsService implements ManageStudentsUseCase {
 
         List<Student> students = studentRepository.findByInstitutionId(institutionId);
 
-        // Build group name lookup to avoid N+1
         Map<UUID, String> groupNames = students.stream()
                 .map(Student::getGroupId)
                 .distinct()
@@ -81,5 +89,131 @@ public class ManageStudentsService implements ManageStudentsUseCase {
         return students.stream()
                 .map(s -> StudentMapper.toDto(s, groupNames.get(s.getGroupId())))
                 .toList();
+    }
+
+    // ── CRUD ────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional
+    public StudentResult.StudentResponse createStudent(StudentCommand.Create command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+
+        GroupEntity group = groupRepository.findById(command.getGroupId())
+                .filter(g -> g.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("Group", command.getGroupId().toString()));
+
+        Student student = new Student();
+        student.setInstitutionId(institutionId);
+        student.setGroupId(group.getId());
+        student.setFirstName(command.getFirstName().trim());
+        student.setLastName(command.getLastName().trim());
+        student.setDateOfBirth(command.getDateOfBirth());
+        student.setStatus("ACTIVE");
+        student.setEnrollmentDate(LocalDate.now());
+
+        Student saved = studentRepository.save(student);
+        return StudentMapper.toStudentResponse(saved, group.getName());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public StudentResult.StudentResponse getById(UUID id) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        Student student = findAndValidateStudent(id, institutionId);
+        String groupName = resolveGroupName(student.getGroupId());
+        return StudentMapper.toStudentResponse(student, groupName);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StudentResult.StudentListItem> list(String status, String search, UUID groupId) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        List<Student> students = studentRepository.findByInstitutionIdAndFilters(institutionId, status, search, groupId);
+
+        if (students.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // Batch: collect all unique groupIds and studentIds
+        List<UUID> studentIds = students.stream().map(Student::getId).toList();
+        Set<UUID> groupIds = students.stream()
+                .map(Student::getGroupId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // Batch load group names (one query per distinct group)
+        Map<UUID, String> groupNameMap = new HashMap<>();
+        for (UUID gId : groupIds) {
+            groupRepository.findById(gId).ifPresent(g -> groupNameMap.put(gId, g.getName()));
+        }
+
+        // Batch load guardian counts (single query)
+        Map<UUID, Long> guardianCountMap = studentGuardianRepository.countByStudentIds(studentIds);
+
+        List<StudentResult.StudentListItem> result = new ArrayList<>();
+        for (Student student : students) {
+            String groupName = student.getGroupId() != null ? groupNameMap.getOrDefault(student.getGroupId(), "") : "";
+            int guardianCount = guardianCountMap.getOrDefault(student.getId(), 0L).intValue();
+            result.add(StudentMapper.toStudentListItem(student, groupName, guardianCount));
+        }
+        return result;
+    }
+
+    @Override
+    @Transactional
+    public StudentResult.StudentResponse update(UUID id, StudentCommand.Update command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        Student student = findAndValidateStudent(id, institutionId);
+
+        student.setFirstName(command.getFirstName().trim());
+        student.setLastName(command.getLastName().trim());
+        student.setDateOfBirth(command.getDateOfBirth());
+
+        Student saved = studentRepository.save(student);
+        return StudentMapper.toStudentResponse(saved, resolveGroupName(saved.getGroupId()));
+    }
+
+    @Override
+    @Transactional
+    public void changeGroup(UUID id, StudentCommand.ChangeGroup command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        Student student = findAndValidateStudent(id, institutionId);
+
+        groupRepository.findById(command.getGroupId())
+                .filter(g -> g.getInstitution().getId().equals(institutionId))
+                .orElseThrow(() -> new EntityNotFoundException("Group", command.getGroupId().toString()));
+
+        student.setGroupId(command.getGroupId());
+        studentRepository.save(student);
+    }
+
+    @Override
+    @Transactional
+    public void changeStatus(UUID id, StudentCommand.ChangeStatus command) {
+        UUID institutionId = tenantProvider.getTenantUUID();
+        Student student = findAndValidateStudent(id, institutionId);
+
+        student.setStatus(command.getStatus());
+        studentRepository.save(student);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private Student findAndValidateStudent(UUID studentId, UUID institutionId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new EntityNotFoundException("Student", studentId.toString()));
+        if (!student.getInstitutionId().equals(institutionId)) {
+            throw new EntityNotFoundException("Student", studentId.toString());
+        }
+        return student;
+    }
+
+    private String resolveGroupName(UUID groupId) {
+        if (groupId == null) {
+            return "";
+        }
+        return groupRepository.findById(groupId)
+                .map(GroupEntity::getName)
+                .orElse("");
     }
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/StudentController.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/input/web/controller/StudentController.java
@@ -1,0 +1,61 @@
+package com.didacta.api.infrastructure.adapter.input.web.controller;
+
+import com.didacta.api.application.dto.StudentCommand;
+import com.didacta.api.application.dto.StudentResult;
+import com.didacta.api.application.port.input.ManageStudentsUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/students")
+@RequiredArgsConstructor
+public class StudentController {
+
+    private final ManageStudentsUseCase manageStudents;
+
+    @PostMapping
+    public ResponseEntity<StudentResult.StudentResponse> create(
+            @Valid @RequestBody StudentCommand.Create command) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(manageStudents.createStudent(command));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<StudentResult.StudentListItem>> list(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) UUID groupId) {
+        return ResponseEntity.ok(manageStudents.list(status, search, groupId));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StudentResult.StudentResponse> getById(@PathVariable UUID id) {
+        return ResponseEntity.ok(manageStudents.getById(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<StudentResult.StudentResponse> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody StudentCommand.Update command) {
+        return ResponseEntity.ok(manageStudents.update(id, command));
+    }
+
+    @PatchMapping("/{id}/group")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeGroup(@PathVariable UUID id,
+                             @Valid @RequestBody StudentCommand.ChangeGroup command) {
+        manageStudents.changeGroup(id, command);
+    }
+
+    @PatchMapping("/{id}/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeStatus(@PathVariable UUID id,
+                              @Valid @RequestBody StudentCommand.ChangeStatus command) {
+        manageStudents.changeStatus(id, command);
+    }
+}

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/StudentGuardianPersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/StudentGuardianPersistenceAdapter.java
@@ -6,7 +6,9 @@ import com.didacta.api.infrastructure.adapter.output.persistence.repository.JpaS
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,6 +41,24 @@ public class StudentGuardianPersistenceAdapter implements StudentGuardianReposit
     @Override
     public boolean existsByStudentIdAndGuardianId(UUID studentId, UUID guardianId) {
         return jpaRepo.existsByStudentIdAndGuardianId(studentId, guardianId);
+    }
+
+    @Override
+    public long countByStudentId(UUID studentId) {
+        return jpaRepo.countByStudentId(studentId);
+    }
+
+    @Override
+    public Map<UUID, Long> countByStudentIds(List<UUID> studentIds) {
+        if (studentIds.isEmpty()) {
+            return new HashMap<>();
+        }
+        List<Object[]> results = jpaRepo.countGroupedByStudentIds(studentIds);
+        Map<UUID, Long> map = new HashMap<>();
+        for (Object[] row : results) {
+            map.put((UUID) row[0], (Long) row[1]);
+        }
+        return map;
     }
 
     @Override

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/StudentPersistenceAdapter.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/adapter/StudentPersistenceAdapter.java
@@ -37,6 +37,21 @@ public class StudentPersistenceAdapter implements StudentRepositoryPort {
     }
 
     @Override
+    public List<Student> findByInstitutionIdAndFilters(UUID institutionId, String status, String search, UUID groupId) {
+        return jpaRepo.findByFilters(institutionId, status, search, groupId);
+    }
+
+    @Override
+    public long countByInstitutionId(UUID institutionId) {
+        return jpaRepo.countByInstitutionId(institutionId);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRepo.deleteById(id);
+    }
+
+    @Override
     public Student save(Student student) {
         return jpaRepo.save(student);
     }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentGuardianRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentGuardianRepository.java
@@ -2,6 +2,8 @@ package com.didacta.api.infrastructure.adapter.output.persistence.repository;
 
 import com.didacta.api.domain.model.StudentGuardian;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +17,9 @@ public interface JpaStudentGuardianRepository extends JpaRepository<StudentGuard
     List<StudentGuardian> findByGuardianId(UUID guardianId);
 
     boolean existsByStudentIdAndGuardianId(UUID studentId, UUID guardianId);
+
+    long countByStudentId(UUID studentId);
+
+    @Query("SELECT sg.studentId, COUNT(sg) FROM StudentGuardian sg WHERE sg.studentId IN :studentIds GROUP BY sg.studentId")
+    List<Object[]> countGroupedByStudentIds(@Param("studentIds") List<UUID> studentIds);
 }

--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentRepository.java
@@ -2,12 +2,28 @@ package com.didacta.api.infrastructure.adapter.output.persistence.repository;
 
 import com.didacta.api.domain.model.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.UUID;
 
+@Repository
 public interface JpaStudentRepository extends JpaRepository<Student, UUID> {
     List<Student> findByGroupId(UUID groupId);
     List<Student> findByInstitutionId(UUID institutionId);
     boolean existsByIdAndInstitutionId(UUID id, UUID institutionId);
+    long countByInstitutionId(UUID institutionId);
+
+    @Query("SELECT s FROM Student s WHERE s.institutionId = :instId " +
+           "AND (:status IS NULL OR s.status = :status) " +
+           "AND (:groupId IS NULL OR s.groupId = :groupId) " +
+           "AND (CAST(:search AS STRING) IS NULL " +
+           "OR LOWER(s.firstName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
+           "OR LOWER(s.lastName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')))")
+    List<Student> findByFilters(@Param("instId") UUID institutionId,
+                                @Param("status") String status,
+                                @Param("search") String search,
+                                @Param("groupId") UUID groupId);
 }

--- a/didacta-web/src/api/studentApi.ts
+++ b/didacta-web/src/api/studentApi.ts
@@ -1,0 +1,33 @@
+import api from './didactaApi';
+import type {
+  StudentResponse,
+  StudentListItem,
+  CreateStudentPayload,
+  UpdateStudentPayload,
+} from '../types/student';
+
+const BASE = '/api/students';
+
+export function createStudent(data: CreateStudentPayload): Promise<StudentResponse> {
+  return api.post<StudentResponse>(BASE, data).then(r => r.data);
+}
+
+export function listStudents(params?: { status?: string; search?: string; groupId?: string }): Promise<StudentListItem[]> {
+  return api.get<StudentListItem[]>(BASE, { params }).then(r => r.data);
+}
+
+export function getStudent(id: string): Promise<StudentResponse> {
+  return api.get<StudentResponse>(`${BASE}/${id}`).then(r => r.data);
+}
+
+export function updateStudent(id: string, data: UpdateStudentPayload): Promise<StudentResponse> {
+  return api.put<StudentResponse>(`${BASE}/${id}`, data).then(r => r.data);
+}
+
+export function changeStudentGroup(id: string, groupId: string): Promise<void> {
+  return api.patch(`${BASE}/${id}/group`, { groupId }).then(() => undefined);
+}
+
+export function changeStudentStatus(id: string, status: string): Promise<void> {
+  return api.patch(`${BASE}/${id}/status`, { status }).then(() => undefined);
+}

--- a/didacta-web/src/components/guardians/LinkStudentToGuardianModal.tsx
+++ b/didacta-web/src/components/guardians/LinkStudentToGuardianModal.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import didactaApi from '../../api/didactaApi';
 import { linkStudentToGuardian } from '../../api/guardianApi';
 import type { Relationship } from '../../types/guardian';
 import { RELATIONSHIP_LABELS } from '../../types/guardian';
 import InlineError from '../InlineError';
+import StudentCreateModal from '../students/StudentCreateModal';
 
 interface StudentOption {
   id: string;
@@ -40,15 +41,26 @@ export default function LinkStudentToGuardianModal({
   const [error, setError] = useState<string | null>(null);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    if (!isOpen) return;
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [previousStudentIds, setPreviousStudentIds] = useState<Set<string>>(new Set());
+
+  const fetchStudents = useCallback(() => {
     setLoadingStudents(true);
     didactaApi
       .get<StudentOption[]>('/api/onboarding/students')
-      .then((res) => setStudents(res.data.filter((s) => !existingStudentIds.includes(s.id))))
+      .then((res) => {
+        const filtered = res.data.filter((s) => !existingStudentIds.includes(s.id));
+        setPreviousStudentIds(new Set(filtered.map((s) => s.id)));
+        setStudents(filtered);
+      })
       .catch(console.error)
       .finally(() => setLoadingStudents(false));
-  }, [isOpen, existingStudentIds]);
+  }, [existingStudentIds]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    fetchStudents();
+  }, [isOpen, fetchStudents]);
 
   const validate = (): boolean => {
     const errors: Record<string, string> = {};
@@ -80,9 +92,33 @@ export default function LinkStudentToGuardianModal({
     }
   };
 
+  const handleStudentCreated = () => {
+    setShowCreateModal(false);
+    setLoadingStudents(true);
+    didactaApi
+      .get<StudentOption[]>('/api/onboarding/students')
+      .then((res) => {
+        const filtered = res.data.filter((s) => !existingStudentIds.includes(s.id));
+        // Auto-select the newly created student
+        const newStudent = filtered.find((s) => !previousStudentIds.has(s.id));
+        if (newStudent) {
+          setSelectedStudentId(newStudent.id);
+          setValidationErrors((prev) => {
+            const { studentId: _, ...rest } = prev;
+            return rest;
+          });
+        }
+        setPreviousStudentIds(new Set(filtered.map((s) => s.id)));
+        setStudents(filtered);
+      })
+      .catch(console.error)
+      .finally(() => setLoadingStudents(false));
+  };
+
   if (!isOpen) return null;
 
   return (
+    <>
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
       <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8 max-h-[90vh] flex flex-col">
         {/* Header */}
@@ -133,6 +169,18 @@ export default function LinkStudentToGuardianModal({
             {validationErrors.studentId && (
               <p className="text-xs text-red-500 mt-1">{validationErrors.studentId}</p>
             )}
+            <button
+              type="button"
+              onClick={() => setShowCreateModal(true)}
+              className="text-sm text-blue-600 hover:text-blue-700 hover:underline mt-1 inline-flex items-center gap-1"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="16" />
+                <line x1="8" y1="12" x2="16" y2="12" />
+              </svg>
+              No encuentras al alumno? Crealo aqui
+            </button>
           </div>
 
           {/* Relationship section */}
@@ -203,6 +251,12 @@ export default function LinkStudentToGuardianModal({
         </div>
       </div>
     </div>
+    <StudentCreateModal
+      isOpen={showCreateModal}
+      onClose={() => setShowCreateModal(false)}
+      onSuccess={handleStudentCreated}
+    />
+    </>
   );
 }
 

--- a/didacta-web/src/components/students/ChangeGroupModal.tsx
+++ b/didacta-web/src/components/students/ChangeGroupModal.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react';
+import didactaApi from '../../api/didactaApi';
+import InlineError from '../InlineError';
+
+interface ChangeGroupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  student: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    groupId: string;
+    groupName: string | null;
+  };
+}
+
+interface GroupOption {
+  id: string;
+  name: string;
+}
+
+export default function ChangeGroupModal({ isOpen, onClose, onSuccess, student }: ChangeGroupModalProps) {
+  const [groups, setGroups] = useState<GroupOption[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const [loadingGroups, setLoadingGroups] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setSelectedGroupId('');
+    setError(null);
+    setLoadingGroups(true);
+
+    didactaApi.get('/api/onboarding/groups')
+      .then(res => setGroups(res.data))
+      .catch(() => setError('No se pudieron cargar los grupos.'))
+      .finally(() => setLoadingGroups(false));
+  }, [isOpen]);
+
+  const selectedGroup = groups.find(g => g.id === selectedGroupId);
+
+  const handleSubmit = async () => {
+    if (!selectedGroupId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await didactaApi.patch(`/api/students/${student.id}/group`, { groupId: selectedGroupId });
+      onSuccess();
+    } catch {
+      setError('No se pudo cambiar el grupo. Intenta de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Cambiar de grupo</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <InlineError message={error} />
+
+          {/* Student info */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Alumno</label>
+            <p className="text-sm text-gray-900 font-medium">{student.firstName} {student.lastName}</p>
+          </div>
+
+          {/* Current group */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Grupo actual</label>
+            <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-50 text-blue-700">
+              {student.groupName || 'Sin grupo'}
+            </span>
+          </div>
+
+          {/* New group select */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Nuevo grupo *</label>
+            {loadingGroups ? (
+              <div className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm text-gray-400">
+                Cargando grupos...
+              </div>
+            ) : (
+              <select
+                value={selectedGroupId}
+                onChange={(e) => { setSelectedGroupId(e.target.value); setError(null); }}
+                className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none bg-white"
+              >
+                <option value="">Selecciona un grupo</option>
+                {groups.map(group => (
+                  <option
+                    key={group.id}
+                    value={group.id}
+                    disabled={group.id === student.groupId}
+                  >
+                    {group.name}{group.id === student.groupId ? ' (actual)' : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {/* Confirmation text */}
+          {selectedGroupId && selectedGroup && (
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-800">
+              Vas a mover a <span className="font-medium">{student.firstName} {student.lastName}</span> de{' '}
+              <span className="font-medium">{student.groupName || 'Sin grupo'}</span> a{' '}
+              <span className="font-medium">{selectedGroup.name}</span>.
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading || !selectedGroupId}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm disabled:opacity-50"
+          >
+            {loading ? 'Cambiando...' : 'Cambiar grupo'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/students/StudentCreateModal.tsx
+++ b/didacta-web/src/components/students/StudentCreateModal.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect } from 'react';
+import { createStudent } from '../../api/studentApi';
+import didactaApi from '../../api/didactaApi';
+import InlineError from '../InlineError';
+
+interface GroupOption {
+  id: string;
+  name: string;
+}
+
+interface StudentCreateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function StudentCreateModal({ isOpen, onClose, onSuccess }: StudentCreateModalProps) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [groupId, setGroupId] = useState('');
+  const [dateOfBirth, setDateOfBirth] = useState('');
+
+  const [groups, setGroups] = useState<GroupOption[]>([]);
+  const [loadingGroups, setLoadingGroups] = useState(true);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+
+  // Load groups when modal opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setLoadingGroups(true);
+    didactaApi
+      .get<GroupOption[]>('/api/onboarding/groups')
+      .then((res) => setGroups(res.data))
+      .catch(() => setError('No se pudieron cargar los grupos.'))
+      .finally(() => setLoadingGroups(false));
+  }, [isOpen]);
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setFirstName('');
+      setLastName('');
+      setGroupId('');
+      setDateOfBirth('');
+      setError(null);
+      setValidationErrors({});
+    }
+  }, [isOpen]);
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!firstName.trim()) errors.firstName = 'El nombre es requerido';
+    if (!lastName.trim()) errors.lastName = 'El apellido es requerido';
+    if (!groupId) errors.groupId = 'El grupo es requerido';
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await createStudent({
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        groupId,
+        dateOfBirth: dateOfBirth || undefined,
+      });
+      onSuccess();
+    } catch (err: unknown) {
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        typeof (err as { response?: { status?: number; data?: { message?: string } } }).response === 'object'
+      ) {
+        const response = (err as { response: { status: number; data?: { message?: string } } }).response;
+        if (response.status === 400 && response.data?.message) {
+          setError(response.data.message);
+        } else {
+          setError('No se pudo crear el alumno. Intenta de nuevo.');
+        }
+      } else {
+        setError('No se pudo crear el alumno. Intenta de nuevo.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Agregar alumno</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <InlineError message={error} />
+
+          {/* Name row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Nombre *</label>
+              <input
+                type="text"
+                value={firstName}
+                onChange={(e) => { setFirstName(e.target.value); setValidationErrors(prev => { const { firstName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.firstName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Sofia"
+              />
+              {validationErrors.firstName && <p className="text-xs text-red-500 mt-1">{validationErrors.firstName}</p>}
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Apellido *</label>
+              <input
+                type="text"
+                value={lastName}
+                onChange={(e) => { setLastName(e.target.value); setValidationErrors(prev => { const { lastName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.lastName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Martinez"
+              />
+              {validationErrors.lastName && <p className="text-xs text-red-500 mt-1">{validationErrors.lastName}</p>}
+            </div>
+          </div>
+
+          {/* Group select */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Grupo *</label>
+            {loadingGroups ? (
+              <div className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm text-gray-400">
+                Cargando grupos...
+              </div>
+            ) : (
+              <select
+                value={groupId}
+                onChange={(e) => { setGroupId(e.target.value); setValidationErrors(prev => { const { groupId: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.groupId ? 'border-red-300' : 'border-gray-300'}`}
+              >
+                <option value="">Seleccionar grupo</option>
+                {groups.map((group) => (
+                  <option key={group.id} value={group.id}>
+                    {group.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            {validationErrors.groupId && <p className="text-xs text-red-500 mt-1">{validationErrors.groupId}</p>}
+          </div>
+
+          {/* Date of birth */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Fecha de nacimiento</label>
+            <input
+              type="date"
+              value={dateOfBirth}
+              onChange={(e) => setDateOfBirth(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading || loadingGroups}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm disabled:opacity-50"
+          >
+            {loading ? 'Guardando...' : 'Guardar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/components/students/StudentEditModal.tsx
+++ b/didacta-web/src/components/students/StudentEditModal.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect } from 'react';
+import { updateStudent } from '../../api/studentApi';
+import InlineError from '../InlineError';
+
+interface StudentEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  student: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    dateOfBirth: string | null;
+  };
+}
+
+export default function StudentEditModal({ isOpen, onClose, onSuccess, student }: StudentEditModalProps) {
+  const [firstName, setFirstName] = useState(student.firstName);
+  const [lastName, setLastName] = useState(student.lastName);
+  const [dateOfBirth, setDateOfBirth] = useState(student.dateOfBirth || '');
+
+  useEffect(() => {
+    setFirstName(student.firstName);
+    setLastName(student.lastName);
+    setDateOfBirth(student.dateOfBirth || '');
+  }, [student.id, student.firstName, student.lastName, student.dateOfBirth]);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!firstName.trim()) errors.firstName = 'El nombre es requerido';
+    if (!lastName.trim()) errors.lastName = 'El apellido es requerido';
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateStudent(student.id, {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        dateOfBirth: dateOfBirth || null,
+      });
+      onSuccess();
+    } catch (err: unknown) {
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        typeof (err as { response?: { status?: number } }).response === 'object' &&
+        (err as { response: { status: number } }).response.status === 400
+      ) {
+        const data = (err as { response: { data?: { message?: string } } }).response.data;
+        setError(data?.message || 'Datos invalidos. Revisa los campos e intenta de nuevo.');
+      } else {
+        setError('No se pudo actualizar el alumno. Intenta de nuevo.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg my-8">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Editar alumno</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          <InlineError message={error} />
+
+          {/* Name row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Nombre *</label>
+              <input
+                type="text"
+                value={firstName}
+                onChange={(e) => { setFirstName(e.target.value); setValidationErrors(prev => { const { firstName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.firstName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Sofia"
+              />
+              {validationErrors.firstName && <p className="text-xs text-red-500 mt-1">{validationErrors.firstName}</p>}
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Apellido *</label>
+              <input
+                type="text"
+                value={lastName}
+                onChange={(e) => { setLastName(e.target.value); setValidationErrors(prev => { const { lastName: _, ...rest } = prev; return rest; }); }}
+                className={`w-full border rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none ${validationErrors.lastName ? 'border-red-300' : 'border-gray-300'}`}
+                placeholder="Ej. Martinez"
+              />
+              {validationErrors.lastName && <p className="text-xs text-red-500 mt-1">{validationErrors.lastName}</p>}
+            </div>
+          </div>
+
+          {/* Date of birth */}
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">Fecha de nacimiento</label>
+            <input
+              type="date"
+              value={dateOfBirth}
+              onChange={(e) => setDateOfBirth(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm disabled:opacity-50"
+          >
+            {loading ? 'Guardando...' : 'Guardar cambios'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/didacta-web/src/types/student.ts
+++ b/didacta-web/src/types/student.ts
@@ -1,0 +1,54 @@
+// --- Response types ---
+
+export interface StudentResponse {
+  id: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string | null;
+  status: string;
+  groupId: string;
+  groupName: string | null;
+  enrollmentDate: string;
+  createdAt: string;
+}
+
+export interface StudentListItem {
+  id: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+  groupId: string;
+  groupName: string | null;
+  guardianCount: number;
+}
+
+// --- Request types ---
+
+export interface CreateStudentPayload {
+  firstName: string;
+  lastName: string;
+  groupId: string;
+  dateOfBirth?: string;
+}
+
+export interface UpdateStudentPayload {
+  firstName: string;
+  lastName: string;
+  dateOfBirth?: string | null;
+}
+
+// --- Domain types ---
+
+export type StudentStatus = 'ACTIVE' | 'INACTIVE';
+
+// --- Label maps ---
+
+export const STUDENT_STATUS_LABELS: Record<StudentStatus, string> = {
+  ACTIVE: 'Activo',
+  INACTIVE: 'Inactivo',
+};
+
+export const STUDENT_STATUS_COLORS: Record<StudentStatus, string> = {
+  ACTIVE: 'bg-green-50 text-green-700',
+  INACTIVE: 'bg-gray-100 text-gray-500',
+};

--- a/didacta-web/src/views/students/StudentListView.tsx
+++ b/didacta-web/src/views/students/StudentListView.tsx
@@ -1,15 +1,11 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { listStudents } from '../../api/studentApi';
+import type { StudentListItem } from '../../types/student';
+import { STUDENT_STATUS_COLORS, STUDENT_STATUS_LABELS } from '../../types/student';
+import type { StudentStatus } from '../../types/student';
+import StudentCreateModal from '../../components/students/StudentCreateModal';
 import didactaApi from '../../api/didactaApi';
-
-interface StudentItem {
-  id: string;
-  firstName: string;
-  lastName: string;
-  status: string;
-  groupId: string | null;
-  groupName: string | null;
-}
 
 interface GroupOption {
   id: string;
@@ -17,72 +13,157 @@ interface GroupOption {
   gradeLevel: string;
 }
 
+type StatusFilter = 'ACTIVE' | 'INACTIVE' | '';
+
 export default function StudentListView() {
   const navigate = useNavigate();
 
-  const [students, setStudents] = useState<StudentItem[]>([]);
+  const [students, setStudents] = useState<StudentListItem[]>([]);
   const [groups, setGroups] = useState<GroupOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [groupFilter, setGroupFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ACTIVE');
+
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(value);
+    }, 300);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Load groups only once on mount
+  useEffect(() => {
+    didactaApi.get<GroupOption[]>('/api/onboarding/groups')
+      .then(res => setGroups(res.data))
+      .catch(console.error);
+  }, []);
 
   const loadData = useCallback(() => {
     setLoading(true);
     setError(null);
-    Promise.all([
-      didactaApi.get<StudentItem[]>('/api/onboarding/students'),
-      didactaApi.get<GroupOption[]>('/api/onboarding/groups'),
-    ])
-      .then(([studentsRes, groupsRes]) => {
-        setStudents(studentsRes.data);
-        setGroups(groupsRes.data);
-      })
+
+    const studentParams: { status?: string; search?: string; groupId?: string } = {};
+    if (statusFilter) studentParams.status = statusFilter;
+    if (debouncedSearch) studentParams.search = debouncedSearch;
+    if (groupFilter) studentParams.groupId = groupFilter;
+
+    listStudents(studentParams)
+      .then(data => setStudents(data))
       .catch(() => setError('No se pudo cargar los alumnos. Intenta de nuevo.'))
       .finally(() => setLoading(false));
-  }, []);
+  }, [statusFilter, debouncedSearch, groupFilter]);
 
   useEffect(() => {
     loadData();
   }, [loadData]);
 
-  const filtered = useMemo(() => {
-    let result = students;
-    if (search) {
-      const term = search.toLowerCase();
-      result = result.filter(
-        (s) =>
-          s.firstName.toLowerCase().includes(term) ||
-          s.lastName.toLowerCase().includes(term) ||
-          `${s.firstName} ${s.lastName}`.toLowerCase().includes(term)
-      );
-    }
-    if (groupFilter) {
-      result = result.filter((s) => s.groupId === groupFilter);
-    }
-    return result;
-  }, [students, search, groupFilter]);
-
-  const hasFilters = search || groupFilter;
+  const hasFilters = debouncedSearch || groupFilter || statusFilter !== 'ACTIVE';
 
   const getInitials = (first: string, last: string) =>
     `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  const getStatusBadge = (status: string) => {
+    const colors = STUDENT_STATUS_COLORS[status as StudentStatus] || 'bg-gray-100 text-gray-500';
+    const label = STUDENT_STATUS_LABELS[status as StudentStatus] || status;
+    return (
+      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors}`}>
+        {label}
+      </span>
+    );
+  };
+
+  const getGuardianLabel = (count: number) => {
+    if (count === 0) return <span className="text-gray-400 text-xs">Sin tutores</span>;
+    return (
+      <span className="text-gray-600 text-sm">
+        {count} {count === 1 ? 'tutor' : 'tutores'}
+      </span>
+    );
+  };
+
+  const handleCreateSuccess = () => {
+    setShowCreateModal(false);
+    loadData();
+  };
 
   return (
     <div className="h-full overflow-y-auto bg-gray-50">
       <div className="max-w-6xl mx-auto p-6 sm:p-8">
         {/* Header */}
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">Alumnos</h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Gestiona los alumnos de tu institucion
-          </p>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Alumnos</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Gestiona los alumnos de tu institucion
+            </p>
+          </div>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium flex items-center gap-2 self-start sm:self-auto"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            Agregar alumno
+          </button>
         </div>
 
         {/* Filters */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 mb-6">
           <div className="flex flex-col sm:flex-row gap-3">
+            {/* Status filter */}
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none"
+            >
+              <option value="ACTIVE">Activos</option>
+              <option value="INACTIVE">Inactivos</option>
+              <option value="">Todos</option>
+            </select>
+
+            {/* Group filter */}
+            {groups.length > 0 && (
+              <select
+                value={groupFilter}
+                onChange={(e) => setGroupFilter(e.target.value)}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none"
+              >
+                <option value="">Todos los grupos</option>
+                {groups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            )}
+
             {/* Search */}
             <div className="relative flex-1">
               <svg
@@ -102,37 +183,22 @@ export default function StudentListView() {
                 type="text"
                 placeholder="Buscar por nombre..."
                 value={search}
-                onChange={(e) => setSearch(e.target.value)}
+                onChange={(e) => handleSearchChange(e.target.value)}
                 className="w-full border border-gray-300 rounded-lg pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 outline-none"
               />
             </div>
-
-            {/* Group filter */}
-            {groups.length > 0 && (
-              <select
-                value={groupFilter}
-                onChange={(e) => setGroupFilter(e.target.value)}
-                className="border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white focus:ring-2 focus:ring-blue-500 outline-none"
-              >
-                <option value="">Todos los grupos</option>
-                {groups.map((g) => (
-                  <option key={g.id} value={g.id}>
-                    {g.name}
-                  </option>
-                ))}
-              </select>
-            )}
           </div>
         </div>
 
         {/* Counter */}
-        <div className="mb-4">
-          <span className="text-sm text-gray-500">
-            {hasFilters
-              ? `${filtered.length} resultados`
-              : `${students.length} alumnos`}
-          </span>
-        </div>
+        {!loading && !error && (
+          <div className="mb-4">
+            <span className="text-sm text-gray-500">
+              {students.length} {students.length === 1 ? 'alumno' : 'alumnos'}
+              {hasFilters ? ' encontrados' : ''}
+            </span>
+          </div>
+        )}
 
         {/* Error state */}
         {error && (
@@ -157,6 +223,7 @@ export default function StudentListView() {
                   <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
                   <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
                   <div className="h-3 w-20 bg-gray-200 rounded animate-pulse" />
+                  <div className="h-3 w-16 bg-gray-200 rounded animate-pulse" />
                 </div>
               </div>
               {[1, 2, 3, 4, 5].map((i) => (
@@ -173,6 +240,7 @@ export default function StudentListView() {
                   </div>
                   <div className="h-3 w-24 bg-gray-200 rounded animate-pulse" />
                   <div className="h-5 w-16 bg-gray-200 rounded-full animate-pulse" />
+                  <div className="h-3 w-20 bg-gray-200 rounded animate-pulse" />
                 </div>
               ))}
             </div>
@@ -197,7 +265,7 @@ export default function StudentListView() {
         )}
 
         {/* Empty state */}
-        {!loading && !error && filtered.length === 0 && (
+        {!loading && !error && students.length === 0 && (
           <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
             <div className="w-16 h-16 rounded-full bg-blue-50 flex items-center justify-center mx-auto mb-4">
               <svg
@@ -232,16 +300,22 @@ export default function StudentListView() {
                 <h3 className="text-lg font-semibold text-gray-900 mb-2">
                   Aun no hay alumnos
                 </h3>
-                <p className="text-gray-500 text-sm">
-                  Los alumnos se agregan durante el proceso de onboarding.
+                <p className="text-gray-500 text-sm mb-4">
+                  Agrega tu primer alumno para comenzar.
                 </p>
+                <button
+                  onClick={() => setShowCreateModal(true)}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm"
+                >
+                  Agregar primer alumno
+                </button>
               </>
             )}
           </div>
         )}
 
         {/* Data */}
-        {!loading && !error && filtered.length > 0 && (
+        {!loading && !error && students.length > 0 && (
           <>
             {/* Desktop table */}
             <div className="hidden md:block bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
@@ -250,11 +324,12 @@ export default function StudentListView() {
                   <tr>
                     <th className="px-6 py-3">NOMBRE</th>
                     <th className="px-6 py-3">GRUPO</th>
+                    <th className="px-6 py-3">ESTADO</th>
                     <th className="px-6 py-3">TUTORES</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100">
-                  {filtered.map((student) => (
+                  {students.map((student) => (
                     <tr
                       key={student.id}
                       onClick={() => navigate(`/alumnos/${student.id}`)}
@@ -270,7 +345,7 @@ export default function StudentListView() {
                               {student.firstName} {student.lastName}
                             </div>
                             {student.groupName && (
-                              <div className="text-xs text-gray-500 truncate">
+                              <div className="text-xs text-gray-500 truncate md:hidden">
                                 {student.groupName}
                               </div>
                             )}
@@ -281,9 +356,10 @@ export default function StudentListView() {
                         {student.groupName || '-'}
                       </td>
                       <td className="px-6 py-4">
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
-                          --
-                        </span>
+                        {getStatusBadge(student.status)}
+                      </td>
+                      <td className="px-6 py-4">
+                        {getGuardianLabel(student.guardianCount)}
                       </td>
                     </tr>
                   ))}
@@ -293,7 +369,7 @@ export default function StudentListView() {
 
             {/* Mobile cards */}
             <div className="md:hidden space-y-3">
-              {filtered.map((student) => (
+              {students.map((student) => (
                 <div
                   key={student.id}
                   onClick={() => navigate(`/alumnos/${student.id}`)}
@@ -308,15 +384,18 @@ export default function StudentListView() {
                         <span className="font-medium text-gray-900 truncate">
                           {student.firstName} {student.lastName}
                         </span>
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 flex-shrink-0">
-                          --
-                        </span>
+                        {getStatusBadge(student.status)}
                       </div>
                       {student.groupName && (
                         <p className="text-xs text-gray-500 mt-0.5">
                           {student.groupName}
                         </p>
                       )}
+                      <p className="text-xs text-gray-400 mt-1">
+                        {student.guardianCount === 0
+                          ? 'Sin tutores'
+                          : `${student.guardianCount} ${student.guardianCount === 1 ? 'tutor' : 'tutores'}`}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -325,6 +404,13 @@ export default function StudentListView() {
           </>
         )}
       </div>
+
+      {/* Create modal */}
+      <StudentCreateModal
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        onSuccess={handleCreateSuccess}
+      />
     </div>
   );
 }

--- a/didacta-web/src/views/students/StudentProfileView.tsx
+++ b/didacta-web/src/views/students/StudentProfileView.tsx
@@ -1,39 +1,59 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import didactaApi from '../../api/didactaApi';
+import { getStudent, changeStudentStatus } from '../../api/studentApi';
 import { getGuardiansOfStudent, unlinkStudent } from '../../api/guardianApi';
-import GuardianLinkModal from '../../components/guardians/GuardianLinkModal';
+import type { StudentResponse } from '../../types/student';
+import { STUDENT_STATUS_LABELS, STUDENT_STATUS_COLORS } from '../../types/student';
+import type { StudentStatus } from '../../types/student';
 import type { GuardianOfStudentResponse, Relationship } from '../../types/guardian';
 import { RELATIONSHIP_LABELS, RELATIONSHIP_COLORS } from '../../types/guardian';
+import GuardianLinkModal from '../../components/guardians/GuardianLinkModal';
+import StudentEditModal from '../../components/students/StudentEditModal';
+import ChangeGroupModal from '../../components/students/ChangeGroupModal';
+import ConfirmDialog from '../../components/staff/ConfirmDialog';
 
-interface StudentDto {
-  id: string;
-  firstName: string;
-  lastName: string;
-  groupId: string | null;
-  groupName: string | null;
-}
-
-interface GroupOption {
-  id: string;
-  name: string;
-  gradeLevel: string;
+function formatDateLong(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('es-MX', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
 }
 
 export default function StudentProfileView() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const [student, setStudent] = useState<StudentDto | null>(null);
-  const [gradeLevel, setGradeLevel] = useState<string | null>(null);
+  const [student, setStudent] = useState<StudentResponse | null>(null);
   const [guardians, setGuardians] = useState<GuardianOfStudentResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [showChangeGroupModal, setShowChangeGroupModal] = useState(false);
   const [showLinkModal, setShowLinkModal] = useState(false);
+  const [showStatusConfirm, setShowStatusConfirm] = useState(false);
+  const [statusLoading, setStatusLoading] = useState(false);
 
   const getInitials = (first: string, last: string) =>
     `${first.charAt(0)}${last.charAt(0)}`.toUpperCase();
+
+  const loadStudent = useCallback(() => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      getStudent(id),
+      getGuardiansOfStudent(id),
+    ])
+      .then(([studentData, guardiansData]) => {
+        setStudent(studentData);
+        setGuardians(guardiansData);
+      })
+      .catch(() => setError('No se pudo cargar el perfil. Intenta de nuevo.'))
+      .finally(() => setLoading(false));
+  }, [id]);
 
   const loadGuardians = useCallback(() => {
     if (!id) return;
@@ -43,32 +63,8 @@ export default function StudentProfileView() {
   }, [id]);
 
   useEffect(() => {
-    if (!id) return;
-    setLoading(true);
-    setError(null);
-
-    Promise.all([
-      didactaApi.get<StudentDto[]>('/api/onboarding/students'),
-      didactaApi.get<GroupOption[]>('/api/onboarding/groups'),
-      getGuardiansOfStudent(id),
-    ])
-      .then(([studentsRes, groupsRes, guardiansRes]) => {
-        const found = studentsRes.data.find(s => s.id === id);
-        if (!found) {
-          setError('No se encontro el alumno.');
-          return;
-        }
-        setStudent(found);
-        setGuardians(guardiansRes);
-
-        if (found.groupId) {
-          const group = groupsRes.data.find(g => g.id === found.groupId);
-          if (group) setGradeLevel(group.gradeLevel);
-        }
-      })
-      .catch(() => setError('No se pudo cargar el perfil. Intenta de nuevo.'))
-      .finally(() => setLoading(false));
-  }, [id]);
+    loadStudent();
+  }, [loadStudent]);
 
   const handleUnlink = async (guardian: GuardianOfStudentResponse) => {
     const confirmed = window.confirm(
@@ -88,6 +84,55 @@ export default function StudentProfileView() {
     setShowLinkModal(false);
     loadGuardians();
   };
+
+  const handleToggleStatus = async () => {
+    if (!student || !id) return;
+
+    const newStatus = student.status === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
+
+    // If deactivating, show confirm dialog
+    if (newStatus === 'INACTIVE') {
+      setShowStatusConfirm(true);
+      return;
+    }
+
+    // Reactivating - no confirmation needed
+    setStatusLoading(true);
+    try {
+      await changeStudentStatus(id, newStatus);
+      loadStudent();
+    } catch {
+      setError('No se pudo cambiar el estado del alumno.');
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  const handleConfirmDeactivate = async () => {
+    if (!id) return;
+    setStatusLoading(true);
+    try {
+      await changeStudentStatus(id, 'INACTIVE');
+      setShowStatusConfirm(false);
+      loadStudent();
+    } catch {
+      setError('No se pudo desactivar al alumno.');
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  const handleEditSuccess = () => {
+    setShowEditModal(false);
+    loadStudent();
+  };
+
+  const handleChangeGroupSuccess = () => {
+    setShowChangeGroupModal(false);
+    loadStudent();
+  };
+
+  const isInactive = student?.status === 'INACTIVE';
 
   // Loading skeleton
   if (loading) {
@@ -110,7 +155,7 @@ export default function StudentProfileView() {
   }
 
   // Error
-  if (error || !student) {
+  if (error && !student) {
     return (
       <div className="h-full overflow-y-auto bg-gray-50">
         <div className="max-w-4xl mx-auto p-6 sm:p-8">
@@ -122,9 +167,9 @@ export default function StudentProfileView() {
             Volver a alumnos
           </button>
           <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
-            <p className="text-red-600 mb-4 text-sm">{error || 'No se encontro el alumno.'}</p>
+            <p className="text-red-600 mb-4 text-sm">{error}</p>
             <button
-              onClick={() => navigate(0)}
+              onClick={loadStudent}
               className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
             >
               Reintentar
@@ -134,6 +179,8 @@ export default function StudentProfileView() {
       </div>
     );
   }
+
+  if (!student) return null;
 
   return (
     <div className="h-full overflow-y-auto bg-gray-50">
@@ -147,21 +194,91 @@ export default function StudentProfileView() {
           Volver a alumnos
         </button>
 
+        {/* Error banner (for action errors) */}
+        {error && (
+          <div className="mb-4 p-3 rounded-lg text-sm font-medium bg-red-50 text-red-700 border border-red-200">
+            {error}
+          </div>
+        )}
+
+        {/* Inactive banner */}
+        {isInactive && (
+          <div className="mb-4 px-4 py-3 rounded-lg bg-yellow-50 border border-yellow-200 text-yellow-800 text-sm font-medium flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" /></svg>
+            Este alumno esta inactivo
+          </div>
+        )}
+
         {/* Header card */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
-          <div className="flex items-center gap-4">
+          <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+            {/* Avatar */}
             <div className="w-16 h-16 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center font-bold text-xl flex-shrink-0">
               {getInitials(student.firstName, student.lastName)}
             </div>
-            <div className="min-w-0">
-              <h1 className="text-xl font-bold text-gray-900">
-                {student.firstName} {student.lastName}
-              </h1>
-              {(student.groupName || gradeLevel) && (
-                <p className="text-sm text-gray-500">
-                  {[student.groupName, gradeLevel].filter(Boolean).join(' - ')}
+
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1 className="text-xl font-bold text-gray-900">
+                  {student.firstName} {student.lastName}
+                </h1>
+                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STUDENT_STATUS_COLORS[student.status as StudentStatus] || 'bg-gray-100 text-gray-700'}`}>
+                  {STUDENT_STATUS_LABELS[student.status as StudentStatus] || student.status}
+                </span>
+              </div>
+
+              <div className="mt-2 space-y-1">
+                {student.groupName && (
+                  <p className="text-sm text-gray-600 flex items-center gap-1.5">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>
+                    Grupo: {student.groupName}
+                  </p>
+                )}
+                {student.dateOfBirth && (
+                  <p className="text-sm text-gray-600 flex items-center gap-1.5">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" /></svg>
+                    Fecha de nacimiento: {formatDateLong(student.dateOfBirth)}
+                  </p>
+                )}
+                <p className="text-sm text-gray-600 flex items-center gap-1.5">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-400 flex-shrink-0"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+                  Fecha de inscripcion: {formatDateLong(student.enrollmentDate)}
                 </p>
-              )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 flex-shrink-0 flex-wrap">
+              <button
+                onClick={() => setShowEditModal(true)}
+                className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium flex items-center gap-1.5"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
+                Editar
+              </button>
+              <button
+                onClick={() => setShowChangeGroupModal(true)}
+                className="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium flex items-center gap-1.5"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 3h5v5" /><line x1="4" y1="20" x2="21" y2="3" /><path d="M21 16v5h-5" /><line x1="15" y1="15" x2="21" y2="21" /><line x1="4" y1="4" x2="9" y2="9" /></svg>
+                Cambiar grupo
+              </button>
+              <button
+                onClick={handleToggleStatus}
+                disabled={statusLoading}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
+                  isInactive
+                    ? 'bg-green-600 text-white hover:bg-green-700'
+                    : 'border border-red-300 text-red-700 hover:bg-red-50'
+                }`}
+              >
+                {statusLoading
+                  ? 'Procesando...'
+                  : isInactive
+                    ? 'Reactivar'
+                    : 'Desactivar'}
+              </button>
             </div>
           </div>
         </div>
@@ -261,6 +378,37 @@ export default function StudentProfileView() {
           onSuccess={handleLinkSuccess}
         />
       )}
+
+      {/* Student Edit Modal */}
+      {showEditModal && student && (
+        <StudentEditModal
+          isOpen={showEditModal}
+          onClose={() => setShowEditModal(false)}
+          onSuccess={handleEditSuccess}
+          student={student}
+        />
+      )}
+
+      {/* Change Group Modal */}
+      {showChangeGroupModal && student && (
+        <ChangeGroupModal
+          isOpen={showChangeGroupModal}
+          onClose={() => setShowChangeGroupModal(false)}
+          onSuccess={handleChangeGroupSuccess}
+          student={student}
+        />
+      )}
+
+      {/* Deactivate Confirm Dialog */}
+      <ConfirmDialog
+        isOpen={showStatusConfirm}
+        title="Desactivar alumno"
+        description={`El alumno ${student.firstName} ${student.lastName} dejara de aparecer en listas activas. Puedes reactivarlo despues.`}
+        confirmLabel="Desactivar"
+        loading={statusLoading}
+        onConfirm={handleConfirmDeactivate}
+        onCancel={() => setShowStatusConfirm(false)}
+      />
     </div>
   );
 }

--- a/docs/specs/students-crud-tasks.md
+++ b/docs/specs/students-crud-tasks.md
@@ -1,0 +1,430 @@
+# Módulo Alumnos CRUD - 14 Tareas Atómicas (PRIORIDAD 1)
+
+## Inventario: Qué ya existe vs qué falta
+
+### Ya existe (backend)
+- `Student.java` entity con campos: id, institutionId, groupId, firstName, lastName, dateOfBirth, guardianName, guardianPhone, guardianEmail, status, enrollmentDate
+- `StudentRepositoryPort` con: save, findByGroupId, findByInstitutionId, findById, existsByIdAndInstitutionId
+- `StudentPersistenceAdapter` implementa todo
+- `JpaStudentRepository` con queries básicas
+- `ManageStudentsUseCase` con: create (bulk, onboarding), listByInstitution
+- `ManageStudentsService` implementa lo anterior
+- `StudentMapper` con toDto
+- Tabla `student` en DB con columnas completas (NO se necesita migración)
+
+### Ya existe (frontend)
+- `StudentListView.tsx` - Lista con búsqueda y filtro por grupo (usa `/api/onboarding/students`)
+- `StudentProfileView.tsx` - Perfil con sección de tutores vinculados
+- Rutas `/alumnos` y `/alumnos/:id` configuradas en App.tsx
+- Sidebar con "Alumnos" activo y navegable
+
+### Qué falta
+- **Backend**: Endpoints propios `/api/students/*`, DTOs dedicados, create individual, update, change group, change status, filtros por status/search/group
+- **Frontend**: Botón "Agregar alumno", formulario de creación, formulario de edición, acción cambiar grupo, acción desactivar/reactivar, filtro por status, migrar de endpoints onboarding a endpoints propios
+
+---
+
+## Grafo de dependencias
+
+```
+TASK-01 (DTOs)         TASK-02 (repo port)
+    |                      |
+    v                      v
+TASK-03 (input port)   TASK-04 (JPA + adapter)
+    |                      |
+    +----------+-----------+
+               |
+               v
+         TASK-05 (Service)
+               |
+               v
+         TASK-06 (Controller)
+               |
+               v
+         TASK-07 (FE types + API)
+            /     |      \
+           v      v       v
+     TASK-08  TASK-09  TASK-10
+        |        |        |
+        v        v        v
+     TASK-11  TASK-12  TASK-13
+               \   /
+                v
+           TASK-14 (integración tutor)
+```
+
+## Paralelizables
+- TASK-01 y TASK-02 (sin dependencias entre sí)
+- TASK-03 y TASK-04 (solo dependen de TASK-01 y TASK-02 respectivamente)
+- TASK-08, TASK-09, TASK-10 (solo dependen de TASK-07)
+- TASK-11, TASK-12, TASK-13 (no dependen entre sí)
+
+---
+
+## TASK-01: DTOs - StudentCommand y StudentResult
+**Story:** ALU-001,002,003,004,005 | **Tipo:** backend | **Depende de:** ninguna
+
+**Archivos:**
+- `application/dto/StudentCommand.java` — DTOs de entrada con Bean Validation
+- `application/dto/StudentResult.java` — DTOs de respuesta
+
+**Spec StudentCommand:**
+```java
+public class StudentCommand {
+    @Data
+    public static class Create {
+        @NotBlank private String firstName;
+        @NotBlank private String lastName;
+        @NotNull private UUID groupId;
+        private LocalDate dateOfBirth;  // opcional
+    }
+
+    @Data
+    public static class Update {
+        @NotBlank private String firstName;
+        @NotBlank private String lastName;
+        private LocalDate dateOfBirth;
+    }
+
+    @Data
+    public static class ChangeGroup {
+        @NotNull private UUID groupId;
+    }
+
+    @Data
+    public static class ChangeStatus {
+        @NotBlank
+        @Pattern(regexp = "ACTIVE|INACTIVE")
+        private String status;
+    }
+}
+```
+
+**Spec StudentResult:**
+```java
+public class StudentResult {
+    @Data @Builder
+    public static class StudentResponse {
+        private UUID id;
+        private String firstName;
+        private String lastName;
+        private LocalDate dateOfBirth;
+        private String status;
+        private UUID groupId;
+        private String groupName;
+        private LocalDate enrollmentDate;
+        private String createdAt;
+    }
+
+    @Data @Builder
+    public static class StudentListItem {
+        private UUID id;
+        private String firstName;
+        private String lastName;
+        private String status;
+        private UUID groupId;
+        private String groupName;
+        private int guardianCount;
+    }
+}
+```
+
+**Done:** [ ] Compila | [ ] @Pattern para status
+
+---
+
+## TASK-02: Ampliar StudentRepositoryPort
+**Story:** ALU-001,004,006 | **Tipo:** backend | **Depende de:** ninguna
+
+**Archivos a MODIFICAR:**
+- `application/port/output/StudentRepositoryPort.java` — agregar métodos
+- `infrastructure/.../repository/JpaStudentRepository.java` — agregar queries
+- `infrastructure/.../adapter/StudentPersistenceAdapter.java` — implementar
+
+**Métodos nuevos en port:**
+```java
+List<Student> findByInstitutionIdAndFilters(UUID institutionId, String status, String search, UUID groupId);
+```
+
+**Query en JpaStudentRepository (IMPORTANTE: usar CAST para evitar lower(bytea)):**
+```java
+@Query("SELECT s FROM Student s WHERE s.institutionId = :instId " +
+       "AND (:status IS NULL OR s.status = :status) " +
+       "AND (:groupId IS NULL OR s.groupId = :groupId) " +
+       "AND (:search IS NULL OR " +
+       "LOWER(s.firstName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) OR " +
+       "LOWER(s.lastName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')))")
+List<Student> findByFilters(...);
+```
+
+**Done:** [ ] Compila | [ ] Query con filtros funciona
+
+---
+
+## TASK-03: Input port - Ampliar ManageStudentsUseCase
+**Story:** ALU-001-007 | **Tipo:** backend | **Depende de:** TASK-01
+
+**Archivos a MODIFICAR:**
+- `application/port/input/ManageStudentsUseCase.java` — agregar métodos nuevos
+
+**Métodos nuevos (mantener existentes):**
+```java
+StudentResult.StudentResponse createStudent(StudentCommand.Create command);
+StudentResult.StudentResponse getById(UUID id);
+List<StudentResult.StudentListItem> list(String status, String search, UUID groupId);
+StudentResult.StudentResponse update(UUID id, StudentCommand.Update command);
+void changeGroup(UUID id, StudentCommand.ChangeGroup command);
+void changeStatus(UUID id, StudentCommand.ChangeStatus command);
+```
+
+**Done:** [ ] Compila
+
+---
+
+## TASK-04: Adapter - implementar nuevos métodos del port
+**Story:** infra | **Tipo:** backend | **Depende de:** TASK-02
+
+**Archivos a MODIFICAR:**
+- `infrastructure/.../adapter/StudentPersistenceAdapter.java` — implementar `findByInstitutionIdAndFilters`
+
+**Done:** [ ] Compila | [ ] Adapter implementa todos los métodos del port
+
+---
+
+## TASK-05: Service - Ampliar ManageStudentsService
+**Story:** ALU-001-006 | **Tipo:** backend | **Depende de:** TASK-01, TASK-02, TASK-03, TASK-04
+
+**Archivos a MODIFICAR:**
+- `application/usecase/ManageStudentsService.java` — agregar implementación de métodos nuevos
+- `application/mapper/StudentMapper.java` — agregar métodos para nuevos DTOs
+
+**Lógica clave:**
+- `createStudent()`: validar grupo existe y pertenece al tenant, crear con status ACTIVE, enrollmentDate = hoy
+- `getById()`: validar que student pertenece al tenant (IDOR), cargar groupName
+- `list()`: delegar a repo con filtros, enriquecer con groupName y guardianCount
+- `update()`: validar IDOR, actualizar solo firstName, lastName, dateOfBirth
+- `changeGroup()`: validar IDOR, validar nuevo grupo pertenece al tenant, actualizar groupId
+- `changeStatus()`: validar IDOR, actualizar status
+- **guardianCount**: Usar `StudentGuardianRepositoryPort.findByStudentId().size()` o agregar `countByStudentId` si no existe
+
+**Done:** [ ] Compila | [ ] IDOR en todas las ops | [ ] enrollmentDate automático
+
+---
+
+## TASK-06: Controller - StudentController
+**Story:** ALU-001-006 | **Tipo:** backend | **Depende de:** TASK-05
+
+**Archivos:**
+- `infrastructure/.../controller/StudentController.java` — NUEVO controller
+
+**Endpoints:**
+```
+POST   /api/students                         → 201
+GET    /api/students                          → 200  (?status=&search=&groupId=)
+GET    /api/students/{id}                     → 200
+PUT    /api/students/{id}                     → 200
+PATCH  /api/students/{id}/group               → 204
+PATCH  /api/students/{id}/status              → 204
+```
+
+**Nota:** Los endpoints `/api/onboarding/students` siguen funcionando. Los nuevos son independientes.
+
+**Done:** [ ] Compila | [ ] @Valid en bodies | [ ] Status codes correctos
+
+---
+
+## TASK-07: Frontend types + API service
+**Story:** infra FE | **Tipo:** frontend | **Depende de:** TASK-06
+
+**Archivos:**
+- `didacta-web/src/types/student.ts` — interfaces TypeScript
+- `didacta-web/src/api/studentApi.ts` — funciones CRUD usando didactaApi
+
+**Spec types:**
+```typescript
+export interface StudentResponse {
+  id: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string | null;
+  status: string;
+  groupId: string;
+  groupName: string | null;
+  enrollmentDate: string;
+  createdAt: string;
+}
+
+export interface StudentListItem {
+  id: string;
+  firstName: string;
+  lastName: string;
+  status: string;
+  groupId: string;
+  groupName: string | null;
+  guardianCount: number;
+}
+
+export interface CreateStudentPayload {
+  firstName: string;
+  lastName: string;
+  groupId: string;
+  dateOfBirth?: string;
+}
+
+export interface UpdateStudentPayload {
+  firstName: string;
+  lastName: string;
+  dateOfBirth?: string;
+}
+```
+
+**Spec API:**
+```typescript
+createStudent(data: CreateStudentPayload): Promise<StudentResponse>
+listStudents(params?: { status?: string; search?: string; groupId?: string }): Promise<StudentListItem[]>
+getStudent(id: string): Promise<StudentResponse>
+updateStudent(id: string, data: UpdateStudentPayload): Promise<StudentResponse>
+changeStudentGroup(id: string, groupId: string): Promise<void>
+changeStudentStatus(id: string, status: string): Promise<void>
+```
+
+**Done:** [ ] `npx tsc --noEmit` pasa
+
+---
+
+## TASK-08: StudentCreateModal
+**Story:** ALU-001 | **Tipo:** frontend | **Depende de:** TASK-07
+
+**Archivos:**
+- `didacta-web/src/components/students/StudentCreateModal.tsx`
+
+**Spec:**
+- Modal con formulario: firstName (required), lastName (required), groupId (select, required), dateOfBirth (date picker, opcional)
+- Select de grupo cargado desde `/api/onboarding/groups`
+- Validación client-side: campos required no vacíos
+- Al guardar: POST `/api/students`, cerrar modal, callback `onSuccess`
+- Manejar errores 400 y mostrar inline
+
+**Done:** [ ] Compila | [ ] Crear funciona | [ ] Errores visibles
+
+---
+
+## TASK-09: StudentEditModal
+**Story:** ALU-002 | **Tipo:** frontend | **Depende de:** TASK-07
+
+**Archivos:**
+- `didacta-web/src/components/students/StudentEditModal.tsx`
+
+**Spec:**
+- Modal pre-llenado con datos actuales del alumno
+- Campos editables: firstName, lastName, dateOfBirth
+- NO editable: grupo (eso es TASK-10 con acción separada)
+- Al guardar: PUT `/api/students/{id}`, cerrar modal, callback `onSuccess`
+
+**Done:** [ ] Compila | [ ] Pre-llena datos | [ ] Actualiza correctamente
+
+---
+
+## TASK-10: ChangeGroupModal
+**Story:** ALU-003 | **Tipo:** frontend | **Depende de:** TASK-07
+
+**Archivos:**
+- `didacta-web/src/components/students/ChangeGroupModal.tsx`
+
+**Spec:**
+- Modal con select de grupos
+- Muestra grupo actual (visual) y nuevo grupo (select)
+- Confirmación: "Vas a mover a [nombre] de [grupo actual] a [grupo nuevo]"
+- Al confirmar: PATCH `/api/students/{id}/group`
+
+**Done:** [ ] Compila | [ ] Cambio funciona | [ ] Confirmación visible
+
+---
+
+## TASK-11: Mejorar StudentListView
+**Story:** ALU-001,004,006 | **Tipo:** frontend | **Depende de:** TASK-07, TASK-08
+
+**Archivos a MODIFICAR:**
+- `didacta-web/src/views/students/StudentListView.tsx`
+
+**Cambios:**
+1. Migrar de `/api/onboarding/students` a `listStudents()` de studentApi
+2. Agregar botón "Agregar alumno" en header (abre StudentCreateModal)
+3. Agregar filtro por status (select: Todos / Activos / Inactivos), default "Activos"
+4. Mostrar badge de status (verde=ACTIVE, gris=INACTIVE) en cada fila
+5. Mostrar guardianCount como número en columna "Tutores"
+6. Mejorar empty state: botón "Agregar primer alumno" que abre el modal
+
+**Done:** [ ] Compila | [ ] Filtro status funciona | [ ] Botón crear funciona | [ ] guardianCount visible
+
+---
+
+## TASK-12: Mejorar StudentProfileView
+**Story:** ALU-002,003,004,005 | **Tipo:** frontend | **Depende de:** TASK-07, TASK-09, TASK-10
+
+**Archivos a MODIFICAR:**
+- `didacta-web/src/views/students/StudentProfileView.tsx`
+
+**Cambios:**
+1. Migrar de `/api/onboarding/students` a `getStudent(id)` de studentApi
+2. Mostrar más datos: dateOfBirth, enrollmentDate, status badge
+3. Agregar botón "Editar" en header card (abre StudentEditModal)
+4. Agregar botón "Cambiar grupo" (abre ChangeGroupModal)
+5. Agregar botón "Desactivar" / "Reactivar" según status actual
+   - Desactivar: confirmación "El alumno dejará de aparecer en listas activas"
+   - Reactivar: PATCH directo
+6. Si alumno INACTIVE: mostrar banner amarillo "Este alumno está inactivo"
+
+**Done:** [ ] Compila | [ ] Editar funciona | [ ] Cambiar grupo funciona | [ ] Desactivar/Reactivar funciona
+
+---
+
+## TASK-13: Verificar StudentGuardianRepositoryPort.countByStudentId
+**Story:** ALU-006 | **Tipo:** backend | **Depende de:** TASK-05
+
+**Archivos a VERIFICAR/MODIFICAR:**
+- `application/port/output/StudentGuardianRepositoryPort.java`
+- `infrastructure/.../repository/JpaStudentGuardianRepository.java`
+- `infrastructure/.../adapter/StudentGuardianPersistenceAdapter.java`
+
+**Spec:** Se necesita `long countByStudentId(UUID studentId)` para que el servicio de students pueda incluir `guardianCount` en la lista.
+
+**Done:** [ ] Método existe o fue agregado | [ ] Compila
+
+---
+
+## TASK-14: Crear alumno desde flujo de tutor (GuardianLinkModal)
+**Story:** ALU-007 | **Tipo:** frontend | **Depende de:** TASK-07, TASK-08
+
+**Archivos a MODIFICAR:**
+- `didacta-web/src/components/guardians/GuardianLinkModal.tsx`
+- Potencialmente `LinkStudentToGuardianModal.tsx`
+
+**Cambios:**
+- Cuando el usuario va a vincular un tutor a un alumno pero el alumno no existe, mostrar botón "¿El alumno no existe? Créalo aquí"
+- Al hacer click: abrir StudentCreateModal (reusar TASK-08)
+- Al crear el alumno exitosamente: seleccionarlo automáticamente en el flujo de vinculación
+
+**Done:** [ ] Compila | [ ] Crear alumno desde flujo tutor funciona
+
+---
+
+## Resumen
+
+| Tipo | Tareas | Esfuerzo |
+|------|--------|----------|
+| Backend DTOs/Ports | 4 (TASK-01 a TASK-04) | S |
+| Backend Service+Controller | 3 (TASK-05, TASK-06, TASK-13) | M |
+| Frontend types+API | 1 (TASK-07) | S |
+| Frontend modals | 3 (TASK-08, TASK-09, TASK-10) | M |
+| Frontend views | 2 (TASK-11, TASK-12) | M |
+| Frontend integración | 1 (TASK-14) | S |
+| **Total** | **14 tareas** | **~2-3 días** |
+
+## Notas de implementación
+
+1. **No hay migración de DB**: La tabla `student` ya tiene todos los campos necesarios. No se necesita V10.
+2. **Endpoints de onboarding no se tocan**: `/api/onboarding/students` siguen funcionando. Los nuevos `/api/students/*` son independientes.
+3. **IDOR en todo**: Cada operación valida que el student pertenece al tenant actual.
+4. **Campos legacy**: `guardianName`, `guardianPhone`, `guardianEmail` en Student no se exponen en DTOs nuevos. La relación con tutores es via `student_guardian`.
+5. **JPQL lower(bytea) fix**: Usar CAST(:search AS STRING) en queries para evitar el bug de PostgreSQL.


### PR DESCRIPTION
## Summary
- Full CRUD for students post-onboarding (create, edit, change group, activate/deactivate)
- 6 new REST endpoints under `/api/students/*` (independent from onboarding endpoints)
- 3 new frontend modals: StudentCreateModal, StudentEditModal, ChangeGroupModal
- Enhanced StudentListView with status filter, create button, and guardian count
- Enhanced StudentProfileView with edit, change group, and deactivate/reactivate actions
- Create student inline from guardian link flow (LinkStudentToGuardianModal integration)
- Batch queries for guardian counts to avoid N+1 performance issues
- IDOR protection on all operations

### Backend
| Method | Path | Status |
|--------|------|--------|
| POST | `/api/students` | 201 |
| GET | `/api/students?status=&search=&groupId=` | 200 |
| GET | `/api/students/{id}` | 200 |
| PUT | `/api/students/{id}` | 200 |
| PATCH | `/api/students/{id}/group` | 204 |
| PATCH | `/api/students/{id}/status` | 204 |

### Frontend
- `StudentCreateModal` - create individual student with group selection
- `StudentEditModal` - edit name and date of birth
- `ChangeGroupModal` - move student between groups with confirmation

Closes #37, Closes #38

## Test plan
- [ ] Create student from list view
- [ ] Edit student from profile view
- [ ] Change student group from profile view
- [ ] Deactivate and reactivate student
- [ ] Filter students by status (active/inactive/all)
- [ ] Search students by name
- [ ] Filter by group
- [ ] Create student inline from guardian link flow
- [ ] Verify guardian count shows correctly in list
- [ ] Verify IDOR: cannot access students from another institution

🤖 Generated with [Claude Code](https://claude.com/claude-code)