### PR TITLE
fix: student search query parameter type

### DIFF
--- a/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentRepository.java
+++ b/didacta-api/src/main/java/com/didacta/api/infrastructure/adapter/output/persistence/repository/JpaStudentRepository.java
@@ -17,8 +17,8 @@ public interface JpaStudentRepository extends JpaRepository<Student, UUID> {
     long countByInstitutionId(UUID institutionId);
 
     @Query("SELECT s FROM Student s WHERE s.institutionId = :instId " +
-           "AND (:status IS NULL OR s.status = :status) " +
-           "AND (:groupId IS NULL OR s.groupId = :groupId) " +
+           "AND (CAST(:status AS STRING) IS NULL OR s.status = :status) " +
+           "AND (CAST(:groupId AS STRING) IS NULL OR CAST(s.groupId AS STRING) = CAST(:groupId AS STRING)) " +
            "AND (CAST(:search AS STRING) IS NULL " +
            "OR LOWER(s.firstName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')) " +
            "OR LOWER(s.lastName) LIKE LOWER(CONCAT('%', CAST(:search AS STRING), '%')))")


### PR DESCRIPTION
## Summary
- Fix PostgreSQL `could not determine data type of parameter $5` error in `GET /api/students`
- Add CAST for nullable `status` and `groupId` parameters in `JpaStudentRepository.findByFilters`
- Same pattern already applied in `JpaGuardianRepository` and `JpaStaffMemberRepository`

Closes #41

## Test plan
- [ ] `GET /api/students` works with no filters
- [ ] `GET /api/students?status=ACTIVE` works
- [ ] `GET /api/students?groupId=<uuid>` works
- [ ] `GET /api/students?search=nombre` works
- [ ] All combinations of filters work

🤖 Generated with [Claude Code](https://claude.com/claude-code)